### PR TITLE
Improve e2e tests

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--xx", dest='fail_fast_e2e', action="store_const", default=False, const=True,
+        help="Fails e2e test immediately"
+    )
+
+
+@pytest.fixture
+def xx(request):
+    return request.config.getoption("--xx")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -3,8 +3,8 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--xx", dest='fail_fast_e2e', action="store_const", default=False, const=True,
-        help="Fails e2e test immediately"
+        "--xx", dest='fail_fast_e2e', action="store_const",
+        default=False, const=True, help="Fails e2e test immediately"
     )
 
 

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -11,29 +11,38 @@ from tests.e2e import executors
 RANDOM_SEED = 1234
 
 
-def exec_e2e_test(estimator, executor_cls):
+def exec_e2e_test(estimator, executor_cls, fail_fast):
     X_test, y_pred_true = utils.train_model(estimator)
     executor = executor_cls(estimator)
+
+    failed_indexes = []
 
     for idx in range(len(X_test)):
         y_pred_executed = executor.predict(X_test[idx])
         print("expected={}, actual={}".format(y_pred_true[idx],
                                               y_pred_executed))
-        assert np.isclose(y_pred_true[idx], y_pred_executed)
+
+        if fail_fast:
+            assert np.isclose(y_pred_true[idx], y_pred_executed)
+        else:
+            if not np.isclose(y_pred_true[idx], y_pred_executed):
+                failed_indexes.append(idx)
+
+    assert failed_indexes == []
 
 
-def test_java_linear():
+def test_java_linear(xx):
     estimator = linear_model.LinearRegression()
-    exec_e2e_test(estimator, executors.JavaExecutor)
+    exec_e2e_test(estimator, executors.JavaExecutor, xx)
 
 
-def test_java_tree():
+def test_java_tree(xx):
     estimator = tree.DecisionTreeRegressor(random_state=RANDOM_SEED)
-    exec_e2e_test(estimator, executors.JavaExecutor)
+    exec_e2e_test(estimator, executors.JavaExecutor, xx)
 
 
 @pytest.mark.skip(reason="Random Forest assembler is broken")
-def test_java_ensemble():
+def test_java_ensemble(xx):
     estimator = ensemble.RandomForestRegressor(n_estimators=10,
                                                random_state=RANDOM_SEED)
-    exec_e2e_test(estimator, executors.JavaExecutor)
+    exec_e2e_test(estimator, executors.JavaExecutor, xx)


### PR DESCRIPTION
1. By default run executor for all X_test even if some fail and print failed
2. Add --xx flag to fail fast