### PR TITLE
Fix e2e tests: use float32 for all thresholds in TreeModelAssembler

### DIFF
--- a/m2cgen/assemblers/tree.py
+++ b/m2cgen/assemblers/tree.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from m2cgen import ast
 from m2cgen.assemblers import utils
 from m2cgen.assemblers.base import ModelAssembler
@@ -35,4 +37,10 @@ class TreeModelAssembler(ModelAssembler):
     def _assemble_cond(self, node_id):
         feature_idx = self._tree.feature[node_id]
         threshold = self._tree.threshold[node_id]
+
+        # sklearn's trees internally work with float32 numbers, so in order to have
+        # consistent results across all supported languages, we convert all thresholds
+        # into float32.
+        threshold = threshold.astype(np.float32)
+
         return utils.lte(ast.FeatureRef(feature_idx), ast.NumVal(threshold))

--- a/m2cgen/assemblers/tree.py
+++ b/m2cgen/assemblers/tree.py
@@ -38,9 +38,9 @@ class TreeModelAssembler(ModelAssembler):
         feature_idx = self._tree.feature[node_id]
         threshold = self._tree.threshold[node_id]
 
-        # sklearn's trees internally work with float32 numbers, so in order to have
-        # consistent results across all supported languages, we convert all thresholds
-        # into float32.
+        # sklearn's trees internally work with float32 numbers, so in order
+        # to have consistent results across all supported languages, we convert
+        # all thresholds into float32.
         threshold = threshold.astype(np.float32)
 
         return utils.lte(ast.FeatureRef(feature_idx), ast.NumVal(threshold))

--- a/tests/e2e/executors/base.py
+++ b/tests/e2e/executors/base.py
@@ -20,3 +20,11 @@ class BaseExecutor:
 
     def prepare(self):
         raise NotImplementedError
+
+    def predict(self, X):
+        assert all(map(lambda x: isinstance(x, float), X)), (
+            "Only list of floats is acceptable.")
+        return self._predict(X)
+
+    def _predict(self, X):
+        raise NotImplementedError

--- a/tests/e2e/executors/base.py
+++ b/tests/e2e/executors/base.py
@@ -20,11 +20,3 @@ class BaseExecutor:
 
     def prepare(self):
         raise NotImplementedError
-
-    def predict(self, X):
-        assert all(map(lambda x: isinstance(x, float), X)), (
-            "Only list of floats is acceptable.")
-        return self._predict(X)
-
-    def _predict(self, X):
-        raise NotImplementedError

--- a/tests/e2e/executors/java.py
+++ b/tests/e2e/executors/java.py
@@ -17,13 +17,14 @@ class JavaExecutor(base.BaseExecutor):
         self._java_bin = os.path.join(java_home, "bin/java")
         self._javac_bin = os.path.join(java_home, "bin/javac")
 
-    def predict(self, X):
+    def _predict(self, X):
 
         exec_args = [
             self._java_bin, "-cp", self._resource_tmp_dir,
             "Executor", "Model", "score"
         ]
         exec_args.extend(map(str, X))
+        print("Predict", " ".join(exec_args))
         result = subprocess.run(exec_args, stdout=subprocess.PIPE)
 
         return float(result.stdout)
@@ -46,5 +47,7 @@ class JavaExecutor(base.BaseExecutor):
                     self._resource_tmp_dir)
 
         # Compile all files together.
-        subprocess.run([self._javac_bin] + files_to_compile + (
-            [os.path.join(self._resource_tmp_dir, "Executor.java")]))
+        exec_args = [self._javac_bin] + files_to_compile + (
+            [os.path.join(self._resource_tmp_dir, "Executor.java")])
+        subprocess.run(exec_args)
+        print("Compile", " ".join(exec_args))

--- a/tests/e2e/executors/java.py
+++ b/tests/e2e/executors/java.py
@@ -24,7 +24,6 @@ class JavaExecutor(base.BaseExecutor):
             "Executor", "Model", "score"
         ]
         exec_args.extend(map(str, X))
-        print("Predict", " ".join(exec_args))
         result = subprocess.run(exec_args, stdout=subprocess.PIPE)
 
         return float(result.stdout)
@@ -49,5 +48,4 @@ class JavaExecutor(base.BaseExecutor):
         # Compile all files together.
         exec_args = [self._javac_bin] + files_to_compile + (
             [os.path.join(self._resource_tmp_dir, "Executor.java")])
-        print("Compile", " ".join(exec_args))
         subprocess.run(exec_args)

--- a/tests/e2e/executors/java.py
+++ b/tests/e2e/executors/java.py
@@ -17,7 +17,7 @@ class JavaExecutor(base.BaseExecutor):
         self._java_bin = os.path.join(java_home, "bin/java")
         self._javac_bin = os.path.join(java_home, "bin/javac")
 
-    def _predict(self, X):
+    def predict(self, X):
 
         exec_args = [
             self._java_bin, "-cp", self._resource_tmp_dir,
@@ -49,5 +49,5 @@ class JavaExecutor(base.BaseExecutor):
         # Compile all files together.
         exec_args = [self._javac_bin] + files_to_compile + (
             [os.path.join(self._resource_tmp_dir, "Executor.java")])
-        subprocess.run(exec_args)
         print("Compile", " ".join(exec_args))
+        subprocess.run(exec_args)

--- a/tests/e2e/executors/python.py
+++ b/tests/e2e/executors/python.py
@@ -35,7 +35,6 @@ class PythonExecutor(base.BaseExecutor):
         _, code = exported_models[0]
 
         file_name = os.path.join(self._resource_tmp_dir, "model.py")
-        print(file_name)
 
         with open(file_name, "w") as f:
             f.write(code)

--- a/tests/e2e/executors/python.py
+++ b/tests/e2e/executors/python.py
@@ -12,7 +12,7 @@ class PythonExecutor(base.BaseExecutor):
         self.model = model
         self.exporter = exporters.PythonExporter(model)
 
-    def _predict(self, X):
+    def predict(self, X):
         # Hacky way to dynamically import generated function
 
         parent_dir = os.path.dirname(self._resource_tmp_dir)
@@ -25,7 +25,8 @@ class PythonExecutor(base.BaseExecutor):
         finally:
             sys.path.pop()
 
-        return score(X)
+        # Use .tolist() since we want to use raw list of floats.
+        return score(X.tolist())
 
     def prepare(self):
         exported_models = self.exporter.export()

--- a/tests/e2e/executors/python.py
+++ b/tests/e2e/executors/python.py
@@ -12,7 +12,7 @@ class PythonExecutor(base.BaseExecutor):
         self.model = model
         self.exporter = exporters.PythonExporter(model)
 
-    def predict(self, X):
+    def _predict(self, X):
         # Hacky way to dynamically import generated function
 
         parent_dir = os.path.dirname(self._resource_tmp_dir)
@@ -34,6 +34,7 @@ class PythonExecutor(base.BaseExecutor):
         _, code = exported_models[0]
 
         file_name = os.path.join(self._resource_tmp_dir, "model.py")
+        print(file_name)
 
         with open(file_name, "w") as f:
             f.write(code)

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -16,7 +16,7 @@ def exec_e2e_test(estimator, executor_cls):
 
     with executor.prepare_then_cleanup():
         for idx in range(len(X_test)):
-            y_pred_executed = executor.predict(X_test[idx].tolist())
+            y_pred_executed = executor.predict(X_test[idx])
             print("expected={}, actual={}".format(y_pred_true[idx],
                                                   y_pred_executed))
             assert np.isclose(y_pred_true[idx], y_pred_executed)

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from sklearn import linear_model
 from sklearn import tree
 from sklearn import ensemble
@@ -17,7 +16,7 @@ def exec_e2e_test(estimator, executor_cls):
 
     with executor.prepare_then_cleanup():
         for idx in range(len(X_test)):
-            y_pred_executed = executor.predict(X_test[idx])
+            y_pred_executed = executor.predict(X_test[idx].tolist())
             print("expected={}, actual={}".format(y_pred_true[idx],
                                                   y_pred_executed))
             assert np.isclose(y_pred_true[idx], y_pred_executed)
@@ -33,7 +32,6 @@ def test_java_tree():
     exec_e2e_test(estimator, executors.JavaExecutor)
 
 
-@pytest.mark.skip(reason="Random Forest assembler is broken")
 def test_java_ensemble():
     estimator = ensemble.RandomForestRegressor(n_estimators=10,
                                                random_state=RANDOM_SEED)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,7 +42,6 @@ def train_model(estimator, test_fraction=0.1):
     boston = load_boston()
 
     X, y = shuffle(boston.data, boston.target, random_state=13)
-    X = X.astype(np.float32)
 
     offset = int(X.shape[0] * (1 - test_fraction))
     X_train, y_train = X[:offset], y[:offset]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,6 @@ import contextlib
 import shutil
 import tempfile
 
-import numpy as np
 from sklearn.datasets import load_boston
 from sklearn.utils import shuffle
 


### PR DESCRIPTION
1. Use float32 for all thresholds in TreeModelAssembler
2. Add printing of commands(Java) and files(python) in Executors. It will only be seen in failed tests.