### PR TITLE
Move is_multi_output to all Expressions; remove MainExpr from ensembles

### DIFF
--- a/m2cgen/assemblers/ensemble.py
+++ b/m2cgen/assemblers/ensemble.py
@@ -15,7 +15,7 @@ class RandomForestModelAssembler(ModelAssembler):
         def assemble_tree_expr(t):
             assembler = TreeModelAssembler(t)
             return ast.BinNumExpr(
-                ast.SubroutineExpr(assembler.assemble().expr),
+                ast.SubroutineExpr(assembler.assemble()),
                 ast.NumVal(coef),
                 ast.BinNumOpType.MUL)
 

--- a/m2cgen/assemblers/linear.py
+++ b/m2cgen/assemblers/linear.py
@@ -7,23 +7,22 @@ from m2cgen.assemblers.base import ModelAssembler
 class LinearModelAssembler(ModelAssembler):
 
     def assemble(self):
-        model_ast, is_multi_output = self._build_ast()
-        return ast.MainExpr(model_ast, is_multi_output=is_multi_output)
+        return self._build_ast()
 
     def _build_ast(self):
         coef = self.model.coef_
         intercept = self.model.intercept_
         if isinstance(coef, np.ndarray) and len(coef.shape) == 2:
             if coef.shape[0] == 1:
-                return _linear_to_ast(coef[0], intercept[0]), False
+                return _linear_to_ast(coef[0], intercept[0])
             else:
                 exprs = []
                 for idx in range(coef.shape[0]):
                     exprs.append(ast.SubroutineExpr(
                         _linear_to_ast(coef[idx], intercept[idx])))
-                return ast.ArrayExpr(exprs), True
+                return ast.ArrayExpr(exprs)
         else:
-            return _linear_to_ast(coef, intercept), False
+            return _linear_to_ast(coef, intercept)
 
 
 def _linear_to_ast(coef, intercept):

--- a/m2cgen/assemblers/tree.py
+++ b/m2cgen/assemblers/tree.py
@@ -17,8 +17,7 @@ class TreeModelAssembler(ModelAssembler):
             self._is_multi_output = self.model.n_classes_ > 1
 
     def assemble(self):
-        return ast.MainExpr(self._assemble_node(0),
-                            is_multi_output=self._is_multi_output)
+        return self._assemble_node(0)
 
     def _assemble_node(self, node_id):
         if self._tree.children_left[node_id] == TREE_LEAF:

--- a/m2cgen/ast.py
+++ b/m2cgen/ast.py
@@ -36,6 +36,9 @@ class BinNumOpType(Enum):
 
 class BinNumExpr(NumExpr):
     def __init__(self, left, right, op):
+        assert not left.is_multi_output, "Only scalars are supported"
+        assert not right.is_multi_output, "Only scalars are supported"
+
         self.left = left
         self.right = right
         self.op = op
@@ -76,6 +79,9 @@ class CompOpType(Enum):
 
 class CompExpr(BoolExpr):
     def __init__(self, left, right, op):
+        assert not left.is_multi_output, "Only scalars are supported"
+        assert not right.is_multi_output, "Only scalars are supported"
+
         self.left = left
         self.right = right
         self.op = op

--- a/m2cgen/interpreters/java/interpreter.py
+++ b/m2cgen/interpreters/java/interpreter.py
@@ -4,7 +4,7 @@ from m2cgen import ast
 from collections import namedtuple
 
 
-Subroutine = namedtuple('Subroutine', ['name', 'is_multi_output', 'expr'])
+Subroutine = namedtuple('Subroutine', ['name', 'expr'])
 
 
 class JavaInterpreter(BaseInterpreter):
@@ -33,7 +33,7 @@ class JavaInterpreter(BaseInterpreter):
                 self._do_interpret(expr)
             else:
                 self._subroutine_expr_queue = [
-                    Subroutine("score", False, expr)
+                    Subroutine("score", expr)
                 ]
 
             while len(self._subroutine_expr_queue) > 0:
@@ -58,13 +58,12 @@ class JavaInterpreter(BaseInterpreter):
         return self._cg.array_init(nested)
 
     def _enqueue_subroutine(self, name, expr):
-        self._subroutine_expr_queue.append(
-            Subroutine(name, expr.is_multi_output, expr.expr))
+        self._subroutine_expr_queue.append(Subroutine(name, expr.expr))
         return name + "(" + self._feature_array_name + ")"
 
     def _process_next_subroutine(self):
         subroutine = self._subroutine_expr_queue.pop(0)
-        is_multi_output = subroutine.is_multi_output
+        is_multi_output = subroutine.expr.is_multi_output
         return_type = "double[]" if is_multi_output else "double"
         self._cg = self._create_code_generator()
 

--- a/tests/assemblers/test_linear.py
+++ b/tests/assemblers/test_linear.py
@@ -13,14 +13,13 @@ def test_single_feature():
     assembler = assemblers.LinearModelAssembler(estimator)
     actual = assembler.assemble()
 
-    expected = ast.MainExpr(
+    expected = ast.BinNumExpr(
+        ast.NumVal(3),
         ast.BinNumExpr(
-            ast.NumVal(3),
-            ast.BinNumExpr(
-                ast.FeatureRef(0),
-                ast.NumVal(1),
-                ast.BinNumOpType.MUL),
-            ast.BinNumOpType.ADD), is_multi_output=False)
+            ast.FeatureRef(0),
+            ast.NumVal(1),
+            ast.BinNumOpType.MUL),
+        ast.BinNumOpType.ADD)
 
     assert utils.cmp_exprs(actual, expected)
 
@@ -33,20 +32,19 @@ def test_two_features():
     assembler = assemblers.LinearModelAssembler(estimator)
     actual = assembler.assemble()
 
-    expected = ast.MainExpr(
+    expected = ast.BinNumExpr(
         ast.BinNumExpr(
+            ast.NumVal(3),
             ast.BinNumExpr(
-                ast.NumVal(3),
-                ast.BinNumExpr(
-                    ast.FeatureRef(0),
-                    ast.NumVal(1),
-                    ast.BinNumOpType.MUL),
-                ast.BinNumOpType.ADD),
-            ast.BinNumExpr(
-                ast.FeatureRef(1),
-                ast.NumVal(2),
+                ast.FeatureRef(0),
+                ast.NumVal(1),
                 ast.BinNumOpType.MUL),
-            ast.BinNumOpType.ADD), is_multi_output=False)
+            ast.BinNumOpType.ADD),
+        ast.BinNumExpr(
+            ast.FeatureRef(1),
+            ast.NumVal(2),
+            ast.BinNumOpType.MUL),
+        ast.BinNumOpType.ADD)
 
     assert utils.cmp_exprs(actual, expected)
 
@@ -59,54 +57,49 @@ def test_multi_class():
     assembler = assemblers.LinearModelAssembler(estimator)
     actual = assembler.assemble()
 
-    expected = ast.MainExpr(
-        ast.ArrayExpr([
-            ast.SubroutineExpr(
+    expected = ast.ArrayExpr([
+        ast.SubroutineExpr(
+            ast.BinNumExpr(
                 ast.BinNumExpr(
+                    ast.NumVal(7),
                     ast.BinNumExpr(
-                        ast.NumVal(7),
-                        ast.BinNumExpr(
-                            ast.FeatureRef(0),
-                            ast.NumVal(1),
-                            ast.BinNumOpType.MUL),
-                        ast.BinNumOpType.ADD),
-                    ast.BinNumExpr(
-                        ast.FeatureRef(1),
-                        ast.NumVal(2),
+                        ast.FeatureRef(0),
+                        ast.NumVal(1),
                         ast.BinNumOpType.MUL),
                     ast.BinNumOpType.ADD),
-                is_multi_output=False),
-            ast.SubroutineExpr(
                 ast.BinNumExpr(
+                    ast.FeatureRef(1),
+                    ast.NumVal(2),
+                    ast.BinNumOpType.MUL),
+                ast.BinNumOpType.ADD)),
+        ast.SubroutineExpr(
+            ast.BinNumExpr(
+                ast.BinNumExpr(
+                    ast.NumVal(8),
                     ast.BinNumExpr(
-                        ast.NumVal(8),
-                        ast.BinNumExpr(
-                            ast.FeatureRef(0),
-                            ast.NumVal(3),
-                            ast.BinNumOpType.MUL),
-                        ast.BinNumOpType.ADD),
-                    ast.BinNumExpr(
-                        ast.FeatureRef(1),
-                        ast.NumVal(4),
+                        ast.FeatureRef(0),
+                        ast.NumVal(3),
                         ast.BinNumOpType.MUL),
                     ast.BinNumOpType.ADD),
-                is_multi_output=False),
-            ast.SubroutineExpr(
                 ast.BinNumExpr(
+                    ast.FeatureRef(1),
+                    ast.NumVal(4),
+                    ast.BinNumOpType.MUL),
+                ast.BinNumOpType.ADD)),
+        ast.SubroutineExpr(
+            ast.BinNumExpr(
+                ast.BinNumExpr(
+                    ast.NumVal(9),
                     ast.BinNumExpr(
-                        ast.NumVal(9),
-                        ast.BinNumExpr(
-                            ast.FeatureRef(0),
-                            ast.NumVal(5),
-                            ast.BinNumOpType.MUL),
-                        ast.BinNumOpType.ADD),
-                    ast.BinNumExpr(
-                        ast.FeatureRef(1),
-                        ast.NumVal(6),
+                        ast.FeatureRef(0),
+                        ast.NumVal(5),
                         ast.BinNumOpType.MUL),
                     ast.BinNumOpType.ADD),
-                is_multi_output=False)]),
-        is_multi_output=True)
+                ast.BinNumExpr(
+                    ast.FeatureRef(1),
+                    ast.NumVal(6),
+                    ast.BinNumOpType.MUL),
+                ast.BinNumOpType.ADD))])
 
     assert utils.cmp_exprs(actual, expected)
 
@@ -119,20 +112,18 @@ def test_binary_class():
     assembler = assemblers.LinearModelAssembler(estimator)
     actual = assembler.assemble()
 
-    expected = ast.MainExpr(
+    expected = ast.BinNumExpr(
         ast.BinNumExpr(
+            ast.NumVal(3),
             ast.BinNumExpr(
-                ast.NumVal(3),
-                ast.BinNumExpr(
-                    ast.FeatureRef(0),
-                    ast.NumVal(1),
-                    ast.BinNumOpType.MUL),
-                ast.BinNumOpType.ADD),
-            ast.BinNumExpr(
-                ast.FeatureRef(1),
-                ast.NumVal(2),
+                ast.FeatureRef(0),
+                ast.NumVal(1),
                 ast.BinNumOpType.MUL),
             ast.BinNumOpType.ADD),
-        is_multi_output=False)
+        ast.BinNumExpr(
+            ast.FeatureRef(1),
+            ast.NumVal(2),
+            ast.BinNumOpType.MUL),
+        ast.BinNumOpType.ADD)
 
     assert utils.cmp_exprs(actual, expected)

--- a/tests/assemblers/test_tree.py
+++ b/tests/assemblers/test_tree.py
@@ -12,15 +12,13 @@ def test_single_condition():
     assembler = assemblers.TreeModelAssembler(estimator)
     actual = assembler.assemble()
 
-    expected = ast.MainExpr(
-        ast.IfExpr(
-            ast.CompExpr(
-                ast.FeatureRef(0),
-                ast.NumVal(1.5),
-                ast.CompOpType.LTE),
-            ast.NumVal(1.0),
-            ast.NumVal(2.0)),
-        is_multi_output=False)
+    expected = ast.IfExpr(
+        ast.CompExpr(
+            ast.FeatureRef(0),
+            ast.NumVal(1.5),
+            ast.CompOpType.LTE),
+        ast.NumVal(1.0),
+        ast.NumVal(2.0))
 
     assert utils.cmp_exprs(actual, expected)
 
@@ -33,21 +31,19 @@ def test_two_conditions():
     assembler = assemblers.TreeModelAssembler(estimator)
     actual = assembler.assemble()
 
-    expected = ast.MainExpr(
+    expected = ast.IfExpr(
+        ast.CompExpr(
+            ast.FeatureRef(0),
+            ast.NumVal(1.5),
+            ast.CompOpType.LTE),
+        ast.NumVal(1.0),
         ast.IfExpr(
             ast.CompExpr(
                 ast.FeatureRef(0),
-                ast.NumVal(1.5),
+                ast.NumVal(2.5),
                 ast.CompOpType.LTE),
-            ast.NumVal(1.0),
-            ast.IfExpr(
-                ast.CompExpr(
-                    ast.FeatureRef(0),
-                    ast.NumVal(2.5),
-                    ast.CompOpType.LTE),
-                ast.NumVal(2.0),
-                ast.NumVal(3.0))),
-        is_multi_output=False)
+            ast.NumVal(2.0),
+            ast.NumVal(3.0)))
 
     assert utils.cmp_exprs(actual, expected)
 
@@ -60,26 +56,24 @@ def test_multi_class():
     assembler = assemblers.TreeModelAssembler(estimator)
     actual = assembler.assemble()
 
-    expected = ast.MainExpr(
+    expected = ast.IfExpr(
+        ast.CompExpr(
+            ast.FeatureRef(0),
+            ast.NumVal(1.5),
+            ast.CompOpType.LTE),
+        ast.ArrayExpr([
+            ast.NumVal(0.0),
+            ast.NumVal(1.0)]),
         ast.IfExpr(
             ast.CompExpr(
                 ast.FeatureRef(0),
-                ast.NumVal(1.5),
+                ast.NumVal(2.5),
                 ast.CompOpType.LTE),
             ast.ArrayExpr([
+                ast.NumVal(1.0),
+                ast.NumVal(0.0)]),
+            ast.ArrayExpr([
                 ast.NumVal(0.0),
-                ast.NumVal(1.0)]),
-            ast.IfExpr(
-                ast.CompExpr(
-                    ast.FeatureRef(0),
-                    ast.NumVal(2.5),
-                    ast.CompOpType.LTE),
-                ast.ArrayExpr([
-                    ast.NumVal(1.0),
-                    ast.NumVal(0.0)]),
-                ast.ArrayExpr([
-                    ast.NumVal(0.0),
-                    ast.NumVal(1.0)]))),
-        is_multi_output=True)
+                ast.NumVal(1.0)])))
 
     assert utils.cmp_exprs(actual, expected)

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -16,7 +16,7 @@ def exec_e2e_test(estimator, executor_cls, model_trainer):
     executor = executor_cls(estimator)
 
     with executor.prepare_then_cleanup():
-        for idx in [0]:
+        for idx in range(len(X_test)):
             y_pred_executed = executor.predict(X_test[idx])
             print("expected={}, actual={}".format(y_pred_true[idx],
                                                   y_pred_executed))

--- a/tests/interpreters/test_java.py
+++ b/tests/interpreters/test_java.py
@@ -193,15 +193,13 @@ def test_multi_output():
                         ast.NumVal(1),
                         ast.CompOpType.EQ),
                     ast.ArrayExpr([ast.NumVal(1), ast.NumVal(2)]),
-                    ast.ArrayExpr([ast.NumVal(3), ast.NumVal(4)])),
-                is_multi_output=True),
-            ast.BinNumOpType.MUL),
-        is_multi_output=True)
+                    ast.ArrayExpr([ast.NumVal(3), ast.NumVal(4)]))),
+            ast.BinNumOpType.MUL))
 
     expected_code = """
 public class Model {
 
-    public static double[] score(double[] input) {
+    public static double score(double[] input) {
         return (input[0]) * (subroutine0(input));
     }
     public static double[] subroutine0(double[] input) {


### PR DESCRIPTION
1. Move is_multi_output to all Expressions
2. Remove MainExpr/is_multi_output from assemblers
3. Remove MainExpr from tests