### PR TITLE
Improvements for e2e tests

### DIFF
--- a/m2cgen/assemblers/linear.py
+++ b/m2cgen/assemblers/linear.py
@@ -10,10 +10,10 @@ class LinearModelAssembler(ModelAssembler):
 
     def _build_ast(self):
         coef = utils.to_2d_array(self.model.coef_)
-        intercept = self.model.intercept_
+        intercept = utils.to_1d_array(self.model.intercept_)
 
         if coef.shape[0] == 1:
-            return _linear_to_ast(coef[0], intercept)
+            return _linear_to_ast(coef[0], intercept[0])
 
         exprs = []
         for idx in range(coef.shape[0]):

--- a/m2cgen/assemblers/linear.py
+++ b/m2cgen/assemblers/linear.py
@@ -25,7 +25,7 @@ class LinearModelAssembler(ModelAssembler):
 def _linear_to_ast(coef, intercept):
     feature_weight_mul_ops = []
 
-    for (index, value) in enumerate(coef):
+    for index, value in enumerate(coef):
         feature_weight_mul_ops.append(
             utils.mul(ast.FeatureRef(index), ast.NumVal(value)))
 

--- a/m2cgen/assemblers/utils.py
+++ b/m2cgen/assemblers/utils.py
@@ -24,6 +24,10 @@ def apply_op_to_expressions(op, *exprs):
     return _inner(ast.BinNumExpr(exprs[0], exprs[1], op), *exprs[2:])
 
 
+def to_1d_array(var):
+    return np.reshape(np.asarray(var), (np.size(var)))
+
+
 def to_2d_array(var):
     if len(np.shape(var)) == 2:
         x, y = var.shape

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--fast", action="store_const",
+        default=False, const=True, help="Run e2e tests fast"
+    )
+
+
+@pytest.fixture
+def is_fast(request):
+    return request.config.getoption("--fast")

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -11,12 +11,14 @@ from tests.e2e import executors
 RANDOM_SEED = 1234
 
 
-def exec_e2e_test(estimator, executor_cls, model_trainer):
+def exec_e2e_test(estimator, executor_cls, model_trainer, is_fast):
     X_test, y_pred_true = model_trainer(estimator)
     executor = executor_cls(estimator)
 
+    idxs_to_test = [0] if is_fast else range(len(X_test))
+
     with executor.prepare_then_cleanup():
-        for idx in range(len(X_test)):
+        for idx in idxs_to_test:
             y_pred_executed = executor.predict(X_test[idx])
             print("expected={}, actual={}".format(y_pred_true[idx],
                                                   y_pred_executed))
@@ -25,58 +27,68 @@ def exec_e2e_test(estimator, executor_cls, model_trainer):
 
 
 @pytest.mark.parametrize("estimator,executor_cls,model_trainer", [
-    (
+    pytest.param(
             linear_model.LinearRegression(),
             executors.JavaExecutor,
-            utils.train_model_regression
+            utils.train_model_regression,
+            marks=pytest.mark.java,
     ),
-    (
+    pytest.param(
             linear_model.LogisticRegression(),
             executors.JavaExecutor,
-            utils.train_model_classification
+            utils.train_model_classification,
+            marks=pytest.mark.java,
     ),
-    (
+    pytest.param(
             linear_model.LogisticRegression(),
             executors.JavaExecutor,
-            utils.train_model_classification_binary
+            utils.train_model_classification_binary,
+            marks=pytest.mark.java,
     ),
-    (
+    pytest.param(
             tree.DecisionTreeRegressor(random_state=RANDOM_SEED),
             executors.JavaExecutor,
-            utils.train_model_regression
+            utils.train_model_regression,
+            marks=pytest.mark.java,
     ),
-    (
+    pytest.param(
             tree.DecisionTreeClassifier(random_state=RANDOM_SEED),
             executors.JavaExecutor,
-            utils.train_model_classification
+            utils.train_model_classification,
+            marks=pytest.mark.java,
     ),
-    (
+    pytest.param(
             tree.DecisionTreeClassifier(random_state=RANDOM_SEED),
             executors.JavaExecutor,
-            utils.train_model_classification_binary
+            utils.train_model_classification_binary,
+            marks=pytest.mark.java,
     ),
-    (
+    pytest.param(
             ensemble.RandomForestRegressor(n_estimators=10,
                                            random_state=RANDOM_SEED),
             executors.JavaExecutor,
-            utils.train_model_regression
+            utils.train_model_regression,
+            marks=pytest.mark.java,
     ),
-    (
+    pytest.param(
             linear_model.LinearRegression(),
             executors.PythonExecutor,
-            utils.train_model_regression
+            utils.train_model_regression,
+            marks=pytest.mark.python,
     ),
-    (
+    pytest.param(
             tree.DecisionTreeRegressor(random_state=RANDOM_SEED),
             executors.PythonExecutor,
-            utils.train_model_regression
+            utils.train_model_regression,
+            marks=pytest.mark.python,
     ),
-    (
+    pytest.param(
             ensemble.RandomForestRegressor(n_estimators=10,
                                            random_state=RANDOM_SEED),
             executors.PythonExecutor,
-            utils.train_model_regression
+            utils.train_model_regression,
+            marks=pytest.mark.python,
     ),
 ])
-def test_e2e(estimator, executor_cls, model_trainer):
-    exec_e2e_test(estimator, executor_cls, model_trainer)
+def test_e2e(estimator, executor_cls, model_trainer, is_fast):
+    exec_e2e_test(estimator, executor_cls, model_trainer, is_fast)


### PR DESCRIPTION
1. Add python/java markers to parameters so that now we can invoke only subset of tests:
`pytest tests/e2e/test_e2e.py -m python`

2. Add `--fast` flag for e2e tests which will limit each combination of model/language to run on a single row from dataset. Useful for development