### PR TITLE
Add ntree-limit fix for XGBoostModelAssembler

### DIFF
--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -84,7 +84,7 @@ class XGBoostModelAssembler(BaseBoostingAssembler):
 
         model_dump = model.get_booster().get_dump(dump_format="json")
 
-        # Respect sklearn ntree_limit
+        # Respect XGBoost ntree_limit
         ntree_limit = getattr(model, "best_ntree_limit", 0)
 
         if ntree_limit > 0:

--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -83,6 +83,13 @@ class XGBoostModelAssembler(BaseBoostingAssembler):
         }
 
         model_dump = model.get_booster().get_dump(dump_format="json")
+
+        # Respect sklearn ntree_limit
+        ntree_limit = getattr(model, "best_ntree_limit", 0)
+
+        if ntree_limit > 0:
+            model_dump = model_dump[:ntree_limit]
+
         trees = [json.loads(d) for d in model_dump]
 
         super().__init__(model, trees, base_score=model.base_score)

--- a/tests/assemblers/test_xgboost.py
+++ b/tests/assemblers/test_xgboost.py
@@ -111,3 +111,38 @@ def test_regression():
             ast.BinNumOpType.ADD))
 
     assert utils.cmp_exprs(actual, expected)
+
+def test_regression_best_ntree_limit():
+    base_score = 0.6
+    estimator = xgboost.XGBRegressor(n_estimators=3, random_state=1,
+                                     max_depth=1, base_score=base_score)
+
+    estimator.best_ntree_limit = 2
+
+    utils.train_model_regression(estimator)
+
+    assembler = assemblers.XGBoostModelAssembler(estimator)
+    actual = assembler.assemble()
+
+    expected = ast.SubroutineExpr(
+        ast.BinNumExpr(
+            ast.BinNumExpr(
+                ast.NumVal(base_score),
+                ast.IfExpr(
+                    ast.CompExpr(
+                        ast.FeatureRef(12),
+                        ast.NumVal(9.72500038),
+                        ast.CompOpType.GTE),
+                    ast.NumVal(1.67318344),
+                    ast.NumVal(2.92757893)),
+                ast.BinNumOpType.ADD),
+            ast.IfExpr(
+                ast.CompExpr(
+                    ast.FeatureRef(5),
+                    ast.NumVal(6.94099998),
+                    ast.CompOpType.GTE),
+                ast.NumVal(3.3400948),
+                ast.NumVal(1.72118247)),
+            ast.BinNumOpType.ADD))
+
+    assert utils.cmp_exprs(actual, expected)

--- a/tests/assemblers/test_xgboost.py
+++ b/tests/assemblers/test_xgboost.py
@@ -112,6 +112,7 @@ def test_regression():
 
     assert utils.cmp_exprs(actual, expected)
 
+
 def test_regression_best_ntree_limit():
     base_score = 0.6
     estimator = xgboost.XGBRegressor(n_estimators=3, random_state=1,


### PR DESCRIPTION
Currently the XGBoostModelAssembler ignores ntree_limit in the XGBoost model. This differs with the sklearn implementation of XGBoost models. This fix respects the ntree_limit (if exists) when building the transpiled model.