### PR TITLE
Fixed missing feature names for XGBoost

### DIFF
--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -84,9 +84,11 @@ class XGBoostModelAssembler(BaseBoostingAssembler):
 
     def __init__(self, model):
         feature_names = model.get_booster().feature_names
-        self._feature_name_to_idx = {
-            name: idx for idx, name in enumerate(feature_names)
-        }
+        self._feature_name_to_idx = {}
+        if feature_names is not None:
+            self._feature_name_to_idx = {
+                name: idx for idx, name in enumerate(feature_names)
+            }
 
         model_dump = model.get_booster().get_dump(dump_format="json")
         trees = [json.loads(d) for d in model_dump]
@@ -103,7 +105,8 @@ class XGBoostModelAssembler(BaseBoostingAssembler):
             return ast.NumVal(tree["leaf"])
 
         threshold = ast.NumVal(tree["split_condition"])
-        feature_idx = self._feature_name_to_idx[tree["split"]]
+        split_feature = tree["split"]
+        feature_idx = self._feature_name_to_idx.get(split_feature, split_feature)
         feature_ref = ast.FeatureRef(feature_idx)
 
         # Since comparison with NaN (missing) value always returns false we

--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -84,11 +84,9 @@ class XGBoostModelAssembler(BaseBoostingAssembler):
 
     def __init__(self, model):
         feature_names = model.get_booster().feature_names
-        self._feature_name_to_idx = {}
-        if feature_names is not None:
-            self._feature_name_to_idx = {
-                name: idx for idx, name in enumerate(feature_names)
-            }
+        self._feature_name_to_idx = {
+            name: idx for idx, name in enumerate(feature_names or [])
+        }
 
         model_dump = model.get_booster().get_dump(dump_format="json")
         trees = [json.loads(d) for d in model_dump]

--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -105,8 +105,8 @@ class XGBoostModelAssembler(BaseBoostingAssembler):
             return ast.NumVal(tree["leaf"])
 
         threshold = ast.NumVal(tree["split_condition"])
-        split_feature = tree["split"]
-        feature_idx = self._feature_name_to_idx.get(split_feature, split_feature)
+        split = tree["split"]
+        feature_idx = self._feature_name_to_idx.get(split, split)
         feature_ref = ast.FeatureRef(feature_idx)
 
         # Since comparison with NaN (missing) value always returns false we

--- a/tests/assemblers/test_xgboost.py
+++ b/tests/assemblers/test_xgboost.py
@@ -1,5 +1,6 @@
 import xgboost
 import numpy as np
+import os
 from tests import utils
 from m2cgen import assemblers, ast
 
@@ -231,21 +232,16 @@ def test_multi_class_best_ntree_limit():
 
 
 def test_regression_saved_without_feature_names():
-    import os
-
     base_score = 0.6
     estimator = xgboost.XGBRegressor(n_estimators=2, random_state=1,
                                      max_depth=1, base_score=base_score)
     utils.train_model_regression(estimator)
 
-    filename = "tmp.file"
-    if os.path.exists(filename):
-        raise OSError("File is already exist")
-    estimator.save_model(filename)
-    estimator = xgboost.XGBRegressor(base_score=base_score)
-    estimator.load_model(filename)
-    if os.path.exists(filename):
-        os.remove(filename)
+    with utils.tmp_dir() as tmp_dirpath:
+        filename = os.path.join(tmp_dirpath, "tmp.file")
+        estimator.save_model(filename)
+        estimator = xgboost.XGBRegressor(base_score=base_score)
+        estimator.load_model(filename)
 
     assembler = assemblers.XGBoostModelAssembler(estimator)
     actual = assembler.assemble()

--- a/tests/assemblers/test_xgboost.py
+++ b/tests/assemblers/test_xgboost.py
@@ -228,3 +228,47 @@ def test_multi_class_best_ntree_limit():
     ])
 
     assert utils.cmp_exprs(actual, expected)
+
+
+def test_regression_saved_without_feature_names():
+    import os
+
+    base_score = 0.6
+    estimator = xgboost.XGBRegressor(n_estimators=2, random_state=1,
+                                     max_depth=1, base_score=base_score)
+    utils.train_model_regression(estimator)
+
+    filename = "tmp.file"
+    if os.path.exists(filename):
+        raise OSError("File is already exist")
+    estimator.save_model(filename)
+    estimator = xgboost.XGBRegressor(base_score=base_score)
+    estimator.load_model(filename)
+    if os.path.exists(filename):
+        os.remove(filename)
+
+    assembler = assemblers.XGBoostModelAssembler(estimator)
+    actual = assembler.assemble()
+
+    expected = ast.SubroutineExpr(
+        ast.BinNumExpr(
+            ast.BinNumExpr(
+                ast.NumVal(base_score),
+                ast.IfExpr(
+                    ast.CompExpr(
+                        ast.FeatureRef(12),
+                        ast.NumVal(9.72500038),
+                        ast.CompOpType.GTE),
+                    ast.NumVal(1.67318344),
+                    ast.NumVal(2.92757893)),
+                ast.BinNumOpType.ADD),
+            ast.IfExpr(
+                ast.CompExpr(
+                    ast.FeatureRef(5),
+                    ast.NumVal(6.94099998),
+                    ast.CompOpType.GTE),
+                ast.NumVal(3.3400948),
+                ast.NumVal(1.72118247)),
+            ast.BinNumOpType.ADD))
+
+    assert utils.cmp_exprs(actual, expected)


### PR DESCRIPTION
Now it's not fail if XGBoost model were saved by save without feature names