### PR TITLE
Codegen for LightGBM Booster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 **/__pycache__
 **/*.pyc
 venv
+build/
+m2cgen.egg-info
+dist

--- a/m2cgen/assemblers/__init__.py
+++ b/m2cgen/assemblers/__init__.py
@@ -16,6 +16,7 @@ SUPPORTED_MODELS = {
     # LightGBM
     "LGBMRegressor": LightGBMModelAssembler,
     "LGBMClassifier": LightGBMModelAssembler,
+    "Booster": LightGBMModelAssembler,
 
     # XGBoost
     "XGBClassifier": XGBoostModelAssembler,

--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -152,6 +152,10 @@ class LightGBMModelAssembler(BaseBoostingAssembler):
         output_size = 1
         if 'num_class' in model_dump:
             output_size = model_dump['num_class']
+            
+            if 'objective' not in model_dump:
+                raise Exception("objective function not specified in model_dump. try upgrading lightgbm >= 2.3.0")
+
             objective = model_dump['objective']
             is_classification = 'multiclass' in objective or 'binary' in objective
             

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@ numpy==1.15.1
 scipy==1.1.0
 scikit-learn==0.20.2
 xgboost==0.80
-lightgbm==2.2.2
+lightgbm==2.3.0
 flake8==3.6.0
 pytest==4.1.1
 pytest-mock==1.10.0

--- a/tests/assemblers/test_lightgbm.py
+++ b/tests/assemblers/test_lightgbm.py
@@ -1,4 +1,5 @@
 import lightgbm
+import os
 import numpy as np
 from tests import utils
 from m2cgen import assemblers, ast
@@ -108,5 +109,75 @@ def test_regression():
                 ast.NumVal(-0.4903836928981587),
                 ast.NumVal(0.7222498915097475)),
             ast.BinNumOpType.ADD))
+
+    assert utils.cmp_exprs(actual, expected)
+
+
+def test_regression_from_booster():
+    estimator = lightgbm.LGBMRegressor(n_estimators=2, random_state=1, max_depth=1)
+    utils.train_model_regression(estimator)
+
+    with utils.tmp_dir() as tmp_dirpath:
+        filename = os.path.join(tmp_dirpath, "model.txt")
+        estimator.booster_.save_model(filename)
+        booster = lightgbm.Booster(model_file=filename)
+
+    assembler = assemblers.LightGBMModelAssembler(booster)
+    actual = assembler.assemble()
+
+    expected = ast.SubroutineExpr(
+        ast.BinNumExpr(
+            ast.BinNumExpr(
+                ast.NumVal(0),
+                ast.IfExpr(
+                    ast.CompExpr(
+                        ast.FeatureRef(5),
+                        ast.NumVal(6.8455),
+                        ast.CompOpType.GT),
+                    ast.NumVal(24.007392728914056),
+                    ast.NumVal(22.35695742616179)),
+                ast.BinNumOpType.ADD),
+            ast.IfExpr(
+                ast.CompExpr(
+                    ast.FeatureRef(12),
+                    ast.NumVal(9.63),
+                    ast.CompOpType.GT),
+                ast.NumVal(-0.4903836928981587),
+                ast.NumVal(0.7222498915097475)),
+            ast.BinNumOpType.ADD))
+
+    assert utils.cmp_exprs(actual, expected)
+
+
+def test_multi_class_from_booster():
+    estimator = lightgbm.LGBMClassifier(n_estimators=1, random_state=1,
+                                        max_depth=1)
+    estimator.fit(np.array([[1], [2], [3]]), np.array([1, 2, 3]))
+
+    with utils.tmp_dir() as tmp_dirpath:
+        filename = os.path.join(tmp_dirpath, "model.txt")
+        estimator.booster_.save_model(filename)
+        booster = lightgbm.Booster(model_file=filename)
+
+    assembler = assemblers.LightGBMModelAssembler(booster)
+    actual = assembler.assemble()
+
+    exponent = ast.ExpExpr(
+        ast.SubroutineExpr(
+            ast.BinNumExpr(
+                ast.NumVal(0.0),
+                ast.NumVal(-1.0986122886681098),
+                ast.BinNumOpType.ADD)),
+        to_reuse=True)
+
+    exponent_sum = ast.BinNumExpr(
+        ast.BinNumExpr(exponent, exponent, ast.BinNumOpType.ADD),
+        exponent,
+        ast.BinNumOpType.ADD,
+        to_reuse=True)
+
+    softmax = ast.BinNumExpr(exponent, exponent_sum, ast.BinNumOpType.DIV)
+
+    expected = ast.VectorVal([softmax] * 3)
 
     assert utils.cmp_exprs(actual, expected)


### PR DESCRIPTION
Allows generating code from `lightgbm.Booster` Fixes https://github.com/BayesWitnesses/m2cgen/issues/99

I tried doing the same for XGBoost but wasn't able to find the right apis to read the necessary attributes (objective function, num classes). Maybe someone with more XGBoost familiarity could take this on.