### PR TITLE
fix Travis to report failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,21 @@ env:
 before_install:
   # Install .NET Core SDK.
   - if [[ $LANG == *"c_sharp"* ]] || [[ $LANG == *"visual_basic"* ]]; then
+      set -e;
       wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb;
       sudo dpkg -i packages-microsoft-prod.deb;
       sudo apt-get update;
       sudo apt-get install --no-install-recommends -y dotnet-sdk-3.0;
+      set +e;
     fi
   # Install PowerShell Core.
   - if [[ $LANG == *"powershell"* ]]; then
+      set -e;
       wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb;
       sudo dpkg -i packages-microsoft-prod.deb;
       sudo apt-get update;
       sudo apt-get install --no-install-recommends -y powershell;
+      set +e;
     fi
 
 install:
@@ -32,12 +36,16 @@ install:
 
 script:
   - if [[ $TEST == "API" ]]; then
+      set -e;
       flake8 .;
       pytest -v tests/ --cov=m2cgen/ --ignore=tests/e2e/;
       coveralls;
+      set +e;
     fi
   - if [[ $TEST == "E2E" ]]; then
+      set -e;
       python setup.py install;
       rm -rfd m2cgen/;
       pytest -v "-m=$LANG" tests/e2e/;
+      set +e;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,40 +12,10 @@ env:
   - TEST=E2E LANG="c_sharp or visual_basic or powershell"
 
 before_install:
-  # Install .NET Core SDK.
-  - if [[ $LANG == *"c_sharp"* ]] || [[ $LANG == *"visual_basic"* ]]; then
-      set -e;
-      wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb;
-      sudo dpkg -i packages-microsoft-prod.deb;
-      sudo apt-get update;
-      sudo apt-get install --no-install-recommends -y dotnet-sdk-3.0;
-      set +e;
-    fi
-  # Install PowerShell Core.
-  - if [[ $LANG == *"powershell"* ]]; then
-      set -e;
-      wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb;
-      sudo dpkg -i packages-microsoft-prod.deb;
-      sudo apt-get update;
-      sudo apt-get install --no-install-recommends -y powershell;
-      set +e;
-    fi
+  - bash .travis/setup.sh
 
 install:
   - pip install -r requirements-test.txt
 
 script:
-  - if [[ $TEST == "API" ]]; then
-      set -e;
-      flake8 .;
-      pytest -v tests/ --cov=m2cgen/ --ignore=tests/e2e/;
-      coveralls;
-      set +e;
-    fi
-  - if [[ $TEST == "E2E" ]]; then
-      set -e;
-      python setup.py install;
-      rm -rfd m2cgen/;
-      pytest -v "-m=$LANG" tests/e2e/;
-      set +e;
-    fi
+  - bash .travis/test.sh

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Install .NET Core SDK.
+if [[ $LANG == *"c_sharp"* ]] || [[ $LANG == *"visual_basic"* ]]; then
+  wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
+  sudo dpkg -i packages-microsoft-prod.deb
+  sudo apt-get update
+  sudo apt-get install --no-install-recommends -y dotnet-sdk-3.0
+fi
+
+# Install PowerShell Core.
+if [[ $LANG == *"powershell"* ]]; then
+  wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
+  sudo dpkg -i packages-microsoft-prod.deb
+  sudo apt-get update
+  sudo apt-get install --no-install-recommends -y powershell
+fi

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+cd $TRAVIS_BUILD_DIR
+
+if [[ $TEST == "API" ]]; then
+  flake8 .
+  pytest -v tests/ --cov=m2cgen/ --ignore=tests/e2e/
+  coveralls
+fi
+
+if [[ $TEST == "E2E" ]]; then
+  python setup.py install
+  rm -rfd m2cgen/
+  pytest -v "-m=$LANG" tests/e2e/
+fi


### PR DESCRIPTION
Refer to https://github.com/travis-ci/travis-ci/issues/1066#issuecomment-32415710.

Seems that without this change Travis reflects only status of the last command in script in the job status.

See the current `master` build as an example of incorrectly reported status: https://travis-ci.org/BayesWitnesses/m2cgen/jobs/629771258?utm_medium=notification&utm_source=github_status.