### PR TITLE
Fix support of older LightGBM versions

### DIFF
--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -208,10 +208,7 @@ class LightGBMModelAssembler(BaseBoostingAssembler):
         trees = [m["tree_structure"] for m in model_dump["tree_info"]]
 
         self.n_iter = len(trees) // model_dump["num_tree_per_iteration"]
-        if "average_output" in model_dump:
-            self.average_output = model_dump["average_output"]
-        else:
-            self.average_output = False
+        self.average_output = model_dump.get("average_output", False)
 
         super().__init__(model, trees,
                          leaves_cutoff_threshold=leaves_cutoff_threshold)

--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -206,8 +206,12 @@ class LightGBMModelAssembler(BaseBoostingAssembler):
                  leaves_cutoff_threshold=LEAVES_CUTOFF_THRESHOLD):
         model_dump = model.booster_.dump_model()
         trees = [m["tree_structure"] for m in model_dump["tree_info"]]
+
         self.n_iter = len(trees) // model_dump["num_tree_per_iteration"]
-        self.average_output = model_dump["average_output"]
+        if "average_output" in model_dump:
+            self.average_output = model_dump["average_output"]
+        else:
+            self.average_output = False
 
         super().__init__(model, trees,
                          leaves_cutoff_threshold=leaves_cutoff_threshold)


### PR DESCRIPTION
Apparently the `average_output` attribute is not available in model dumps from older LightGBM versions (tested with 2.2.2).