### PR TITLE
remove scikit-learn and scipy from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ $ m2cgen <pickle_file> --language <language> [--indent <indent>] [--class_name <
          [--module_name <module_name>] [--package_name <package_name>] [--namespace <namespace>]
          [--recursion-limit <recursion_limit>]
 ```
+Don't forget that for unpickling serialized model objects their classes must be defined in the top level of an importable module in the unpickling environment.
 
 Piping is also supported:
 ```
@@ -118,3 +119,7 @@ $ cat <pickle_file> | m2cgen --language <language>
 **Q: Generation fails with `RuntimeError: maximum recursion depth exceeded` error.**
 
 A: If this error occurs while generating code using an ensemble model, try to reduce the number of trained estimators within that model. Alternatively you can increase the maximum recursion depth with `sys.setrecursionlimit(<new_depth>)`.
+
+**Q: Generation fails with `ImportError: No module named <module_name_here>` error while transpiling model from a serialized model object.**
+
+A: This error indicates that pickle protocol cannot deserialize model object. For unpickling serialized model objects, it is required that their classes must be defined in the top level of an importable module in the unpickling environment. So installation of package which provided model's class definition should solve the problem.

--- a/m2cgen/assemblers/tree.py
+++ b/m2cgen/assemblers/tree.py
@@ -3,8 +3,11 @@ import numpy as np
 from m2cgen import ast
 from m2cgen.assemblers import utils
 from m2cgen.assemblers.base import ModelAssembler
-from sklearn import tree
-from sklearn.tree._tree import TREE_LEAF
+
+
+# refer to
+# https://github.com/scikit-learn/scikit-learn/blob/fd12d5684ad224ad7760374b1dcca2821c644feb/sklearn/tree/_tree.pyx#L64
+TREE_LEAF = -1
 
 
 class TreeModelAssembler(ModelAssembler):
@@ -13,7 +16,8 @@ class TreeModelAssembler(ModelAssembler):
         super().__init__(model)
         self._tree = model.tree_
         self._is_vector_output = False
-        if isinstance(self.model, tree.DecisionTreeClassifier):
+        if type(self.model).__name__ in {"DecisionTreeClassifier",
+                                         "ExtraTreeClassifier"}:
             self._is_vector_output = self.model.n_classes_ > 1
 
     def assemble(self):

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,6 @@ setup(
     python_requires=">=3.5",
     install_requires=[
         "numpy",
-        "scipy",
-        "scikit-learn",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
`scikit-learn` and `scipy` are quite "heavy" dependencies and rather often have conflicts with certain versions of other ML libraries. Dropping them from a list of required packages for `m2cgen` installation will allow users to be freer in configuring their virtual environments.

Some more my thoughts about the need of removing excess dependencies can be found in https://github.com/BayesWitnesses/m2cgen/issues/108#issue-508121116.

We do not require installation of `LightGBM` or `XGBoost`, for instance, to generate a code from their models. So I don't see any reasons why we should do this for `scikit-learn`. 