### PR TITLE
add: Make function_name parametrized

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ public class Model {
 
 `m2cgen` can be used as a CLI tool to generate code using serialized model objects (pickle protocol):
 ```
-$ m2cgen <pickle_file> --language <language> [--indent <indent>] [--class_name <class_name>]
-         [--module_name <module_name>] [--package_name <package_name>] [--namespace <namespace>]
-         [--recursion-limit <recursion_limit>]
+$ m2cgen <pickle_file> --language <language> [--indent <indent>] [--function_name <function_name>]
+         [--class_name <class_name>] [--module_name <module_name>] [--package_name <package_name>]
+         [--namespace <namespace>] [--recursion-limit <recursion_limit>]
 ```
 Don't forget that for unpickling serialized model objects their classes must be defined in the top level of an importable module in the unpickling environment.
 

--- a/m2cgen/cli.py
+++ b/m2cgen/cli.py
@@ -52,6 +52,9 @@ parser.add_argument(
     required=True)
 parser.add_argument(
     "--function_name", "-fn", dest="function_name", type=str,
+    # The default value is conditional and will be set in the argument's
+    # post-processing, based on the signature of the `export` function
+    # that belongs to the specified target language.
     default=None,
     help="Name of the function in the generated code.")
 parser.add_argument(

--- a/m2cgen/cli.py
+++ b/m2cgen/cli.py
@@ -39,39 +39,39 @@ MAX_RECURSION_DEPTH = np.iinfo(np.intc).max
 
 parser = argparse.ArgumentParser(
     prog="m2cgen",
-    description="Generate code in native language for provided model")
+    description="Generate code in native language for provided model.")
 parser.add_argument(
     "infile", type=argparse.FileType("rb"), nargs="?",
     default=sys.stdin.buffer,
-    help="File with pickle representation of the model")
+    help="File with pickle representation of the model.")
 parser.add_argument(
     "--language", "-l", type=str,
     choices=LANGUAGE_TO_EXPORTER.keys(),
-    help="Target language",
+    help="Target language.",
     required=True)
 parser.add_argument(
     "--function_name", "-fn", dest="function_name", type=str,
     default="score",
-    help="Name of the function in the generated code (defaults to 'score')")
+    help="Name of the function in the generated code.")
 parser.add_argument(
     "--class_name", "-cn", dest="class_name", type=str,
-    help="Name of the generated class (if supported by target language)")
+    help="Name of the generated class (if supported by target language).")
 parser.add_argument(
     "--package_name", "-pn", dest="package_name", type=str,
     help="Package name for the generated code "
-         "(if supported by target language)")
+         "(if supported by target language).")
 parser.add_argument(
     "--module_name", "-mn", dest="module_name", type=str,
     help="Module name for the generated code "
-         "(if supported by target language)")
+         "(if supported by target language).")
 parser.add_argument(
     "--namespace", "-ns", dest="namespace", type=str,
     help="Namespace for the generated code "
-         "(if supported by target language)")
+         "(if supported by target language).")
 parser.add_argument(
     "--indent", "-i", dest="indent", type=int,
     default=4,
-    help="Indentation for the generated code")
+    help="Indentation for the generated code.")
 parser.add_argument(
     "--recursion-limit", "-rl", type=int,
     help="Sets the maximum depth of the Python interpreter stack. "

--- a/m2cgen/cli.py
+++ b/m2cgen/cli.py
@@ -17,18 +17,19 @@ import m2cgen
 
 
 LANGUAGE_TO_EXPORTER = {
-    "python": (m2cgen.export_to_python, ["indent"]),
-    "java": (m2cgen.export_to_java, ["indent", "class_name", "package_name"]),
-    "c": (m2cgen.export_to_c, ["indent"]),
-    "go": (m2cgen.export_to_go, ["indent"]),
-    "javascript": (m2cgen.export_to_javascript, ["indent"]),
+    "python": (m2cgen.export_to_python, ["indent", "function_name"]),
+    "java": (m2cgen.export_to_java, ["indent", "class_name", "package_name",
+                                     "function_name"]),
+    "c": (m2cgen.export_to_c, ["indent", "function_name"]),
+    "go": (m2cgen.export_to_go, ["indent", "function_name"]),
+    "javascript": (m2cgen.export_to_javascript, ["indent", "function_name"]),
     "visual_basic": (m2cgen.export_to_visual_basic,
-                     ["module_name", "indent"]),
+                     ["module_name", "indent", "function_name"]),
     "c_sharp": (m2cgen.export_to_c_sharp,
-                ["indent", "class_name", "namespace"]),
-    "powershell": (m2cgen.export_to_powershell, ["indent"]),
-    "r": (m2cgen.export_to_r, ["indent"]),
-    "php": (m2cgen.export_to_php, ["indent"]),
+                ["indent", "class_name", "namespace", "function_name"]),
+    "powershell": (m2cgen.export_to_powershell, ["indent", "function_name"]),
+    "r": (m2cgen.export_to_r, ["indent", "function_name"]),
+    "php": (m2cgen.export_to_php, ["indent", "function_name"]),
 }
 
 
@@ -48,6 +49,10 @@ parser.add_argument(
     choices=LANGUAGE_TO_EXPORTER.keys(),
     help="Target language",
     required=True)
+parser.add_argument(
+    "--function_name", "-fn", dest="function_name", type=str,
+    default="score",
+    help="Name of the function in the generated code (defaults to 'score')")
 parser.add_argument(
     "--class_name", "-cn", dest="class_name", type=str,
     help="Name of the generated class (if supported by target language)")

--- a/m2cgen/exporters.py
+++ b/m2cgen/exporters.py
@@ -2,7 +2,8 @@ from m2cgen import assemblers
 from m2cgen import interpreters
 
 
-def export_to_java(model, package_name=None, class_name="Model", indent=4):
+def export_to_java(model, package_name=None, class_name="Model", indent=4,
+                   function_name="score"):
     """
     Generates a Java code representation of the given model.
 
@@ -16,6 +17,8 @@ def export_to_java(model, package_name=None, class_name="Model", indent=4):
         The name of the generated class.
     indent : int, optional
         The size of indents in the generated code.
+    function_name : string, optional
+        Name of the function in the generated code (defaults to 'score')
 
     Returns
     -------
@@ -24,11 +27,13 @@ def export_to_java(model, package_name=None, class_name="Model", indent=4):
     interpreter = interpreters.JavaInterpreter(
         package_name=package_name,
         class_name=class_name,
-        indent=indent)
+        indent=indent,
+        function_name=function_name
+    )
     return _export(model, interpreter)
 
 
-def export_to_python(model, indent=4):
+def export_to_python(model, indent=4, function_name="score"):
     """
     Generates a Python code representation of the given model.
 
@@ -38,16 +43,21 @@ def export_to_python(model, indent=4):
         The model object that should be transpiled into code.
     indent : int, optional
         The size of indents in the generated code.
+    function_name : string, optional
+        Name of the function in the generated code (defaults to 'score')
 
     Returns
     -------
     code : string
     """
-    interpreter = interpreters.PythonInterpreter(indent=indent)
+    interpreter = interpreters.PythonInterpreter(
+        indent=indent,
+        function_name=function_name
+    )
     return _export(model, interpreter)
 
 
-def export_to_c(model, indent=4):
+def export_to_c(model, indent=4, function_name="score"):
     """
     Generates a C code representation of the given model.
 
@@ -57,16 +67,21 @@ def export_to_c(model, indent=4):
         The model object that should be transpiled into code.
     indent : int, optional
         The size of indents in the generated code.
+    function_name : string, optional
+        Name of the function in the generated code (defaults to 'score')
 
     Returns
     -------
     code : string
     """
-    interpreter = interpreters.CInterpreter(indent=indent)
+    interpreter = interpreters.CInterpreter(
+        indent=indent,
+        function_name=function_name
+    )
     return _export(model, interpreter)
 
 
-def export_to_go(model, indent=4):
+def export_to_go(model, indent=4, function_name="score"):
     """
     Generates a Go code representation of the given model.
 
@@ -76,16 +91,21 @@ def export_to_go(model, indent=4):
         The model object that should be transpiled into code.
     indent : int, optional
         The size of indents in the generated code.
+    function_name : string, optional
+        Name of the function in the generated code (defaults to 'score')
 
     Returns
     -------
     code : string
     """
-    interpreter = interpreters.GoInterpreter(indent=indent)
+    interpreter = interpreters.GoInterpreter(
+        indent=indent,
+        function_name=function_name
+    )
     return _export(model, interpreter)
 
 
-def export_to_javascript(model, indent=4):
+def export_to_javascript(model, indent=4, function_name="score"):
     """
     Generates a JavaScript code representation of the given model.
 
@@ -95,16 +115,22 @@ def export_to_javascript(model, indent=4):
         The model object that should be transpiled into code.
     indent : int, optional
         The size of indents in the generated code.
+    function_name : string, optional
+        Name of the function in the generated code (defaults to 'score')
 
     Returns
     -------
     code : string
     """
-    interpreter = interpreters.JavascriptInterpreter(indent=indent)
+    interpreter = interpreters.JavascriptInterpreter(
+        indent=indent,
+        function_name=function_name
+    )
     return _export(model, interpreter)
 
 
-def export_to_visual_basic(model, module_name="Model", indent=4):
+def export_to_visual_basic(model, module_name="Model", indent=4,
+                           function_name="score"):
     """
     Generates a Visual Basic (also can be treated as VBA
     with some small manual changes, see a note below)
@@ -158,17 +184,23 @@ def export_to_visual_basic(model, module_name="Model", indent=4):
         The name of the generated module.
     indent : int, optional
         The size of indents in the generated code.
+    function_name : string, optional
+        Name of the function in the generated code (defaults to 'score')
 
     Returns
     -------
     code : string
     """
-    interpreter = interpreters.VisualBasicInterpreter(module_name=module_name,
-                                                      indent=indent)
+    interpreter = interpreters.VisualBasicInterpreter(
+        module_name=module_name,
+        indent=indent,
+        function_name=function_name
+    )
     return _export(model, interpreter)
 
 
-def export_to_c_sharp(model, namespace="ML", class_name="Model", indent=4):
+def export_to_c_sharp(model, namespace="ML", class_name="Model", indent=4,
+                      function_name="Score"):
     """
     Generates a C# code representation of the given model.
 
@@ -182,6 +214,8 @@ def export_to_c_sharp(model, namespace="ML", class_name="Model", indent=4):
         The name of the generated class.
     indent : int, optional
         The size of indents in the generated code.
+    function_name : string, optional
+        Name of the function in the generated code (defaults to 'Score')
 
     Returns
     -------
@@ -190,11 +224,13 @@ def export_to_c_sharp(model, namespace="ML", class_name="Model", indent=4):
     interpreter = interpreters.CSharpInterpreter(
         namespace=namespace,
         class_name=class_name,
-        indent=indent)
+        indent=indent,
+        function_name=function_name
+    )
     return _export(model, interpreter)
 
 
-def export_to_powershell(model, indent=4):
+def export_to_powershell(model, indent=4, function_name="Score"):
     """
     Generates a PowerShell code representation of the given model.
 
@@ -204,16 +240,21 @@ def export_to_powershell(model, indent=4):
         The model object that should be transpiled into code.
     indent : int, optional
         The size of indents in the generated code.
+    function_name : string, optional
+        Name of the function in the generated code (defaults to 'Score')
 
     Returns
     -------
     code : string
     """
-    interpreter = interpreters.PowershellInterpreter(indent=indent)
+    interpreter = interpreters.PowershellInterpreter(
+        indent=indent,
+        function_name=function_name
+    )
     return _export(model, interpreter)
 
 
-def export_to_r(model, indent=4):
+def export_to_r(model, indent=4, function_name="score"):
     """
     Generates a R code representation of the given model.
 
@@ -223,16 +264,21 @@ def export_to_r(model, indent=4):
         The model object that should be transpiled into code.
     indent : int, optional
         The size of indents in the generated code.
+    function_name : string, optional
+        Name of the function in the generated code (defaults to 'score')
 
     Returns
     -------
     code : string
     """
-    interpreter = interpreters.RInterpreter(indent=indent)
+    interpreter = interpreters.RInterpreter(
+        indent=indent,
+        function_name=function_name
+    )
     return _export(model, interpreter)
 
 
-def export_to_php(model, indent=4):
+def export_to_php(model, indent=4, function_name="score"):
     """
     Generates a PHP code representation of the given model.
 
@@ -242,12 +288,17 @@ def export_to_php(model, indent=4):
         The model object that should be transpiled into code.
     indent : int, optional
         The size of indents in the generated code.
+    function_name : string, optional
+        Name of the function in the generated code (defaults to 'score')
 
     Returns
     -------
     code : string
     """
-    interpreter = interpreters.PhpInterpreter(indent=indent)
+    interpreter = interpreters.PhpInterpreter(
+        indent=indent,
+        function_name=function_name
+    )
     return _export(model, interpreter)
 
 

--- a/m2cgen/exporters.py
+++ b/m2cgen/exporters.py
@@ -18,7 +18,7 @@ def export_to_java(model, package_name=None, class_name="Model", indent=4,
     indent : int, optional
         The size of indents in the generated code.
     function_name : string, optional
-        Name of the function in the generated code (defaults to 'score')
+        Name of the function in the generated code.
 
     Returns
     -------
@@ -44,7 +44,7 @@ def export_to_python(model, indent=4, function_name="score"):
     indent : int, optional
         The size of indents in the generated code.
     function_name : string, optional
-        Name of the function in the generated code (defaults to 'score')
+        Name of the function in the generated code.
 
     Returns
     -------
@@ -68,7 +68,7 @@ def export_to_c(model, indent=4, function_name="score"):
     indent : int, optional
         The size of indents in the generated code.
     function_name : string, optional
-        Name of the function in the generated code (defaults to 'score')
+        Name of the function in the generated code.
 
     Returns
     -------
@@ -92,7 +92,7 @@ def export_to_go(model, indent=4, function_name="score"):
     indent : int, optional
         The size of indents in the generated code.
     function_name : string, optional
-        Name of the function in the generated code (defaults to 'score')
+        Name of the function in the generated code.
 
     Returns
     -------
@@ -116,7 +116,7 @@ def export_to_javascript(model, indent=4, function_name="score"):
     indent : int, optional
         The size of indents in the generated code.
     function_name : string, optional
-        Name of the function in the generated code (defaults to 'score')
+        Name of the function in the generated code.
 
     Returns
     -------
@@ -185,7 +185,7 @@ def export_to_visual_basic(model, module_name="Model", indent=4,
     indent : int, optional
         The size of indents in the generated code.
     function_name : string, optional
-        Name of the function in the generated code (defaults to 'score')
+        Name of the function in the generated code.
 
     Returns
     -------
@@ -215,7 +215,7 @@ def export_to_c_sharp(model, namespace="ML", class_name="Model", indent=4,
     indent : int, optional
         The size of indents in the generated code.
     function_name : string, optional
-        Name of the function in the generated code (defaults to 'Score')
+        Name of the function in the generated code.
 
     Returns
     -------
@@ -241,7 +241,7 @@ def export_to_powershell(model, indent=4, function_name="Score"):
     indent : int, optional
         The size of indents in the generated code.
     function_name : string, optional
-        Name of the function in the generated code (defaults to 'Score')
+        Name of the function in the generated code.
 
     Returns
     -------
@@ -265,7 +265,7 @@ def export_to_r(model, indent=4, function_name="score"):
     indent : int, optional
         The size of indents in the generated code.
     function_name : string, optional
-        Name of the function in the generated code (defaults to 'score')
+        Name of the function in the generated code.
 
     Returns
     -------
@@ -289,7 +289,7 @@ def export_to_php(model, indent=4, function_name="score"):
     indent : int, optional
         The size of indents in the generated code.
     function_name : string, optional
-        Name of the function in the generated code (defaults to 'score')
+        Name of the function in the generated code.
 
     Returns
     -------

--- a/m2cgen/interpreters/c/interpreter.py
+++ b/m2cgen/interpreters/c/interpreter.py
@@ -21,7 +21,9 @@ class CInterpreter(ToCodeInterpreter,
     power_function_name = "pow"
     tanh_function_name = "tanh"
 
-    def __init__(self, indent=4, *args, **kwargs):
+    def __init__(self, indent=4, function_name="score", *args, **kwargs):
+        self.function_name = function_name
+
         cg = CCodeGenerator(indent=indent)
         super(CInterpreter, self).__init__(cg, *args, **kwargs)
 

--- a/m2cgen/interpreters/c/interpreter.py
+++ b/m2cgen/interpreters/c/interpreter.py
@@ -39,7 +39,7 @@ class CInterpreter(ToCodeInterpreter,
             args += [(True, "output")]
 
         with self._cg.function_definition(
-                name="score",
+                name=self.function_name,
                 args=args,
                 is_scalar_output=expr.output_size == 1):
 

--- a/m2cgen/interpreters/c_sharp/interpreter.py
+++ b/m2cgen/interpreters/c_sharp/interpreter.py
@@ -22,10 +22,11 @@ class CSharpInterpreter(ToCodeInterpreter, mixins.LinearAlgebraMixin):
     tanh_function_name = "Tanh"
 
     def __init__(self, namespace="ML", class_name="Model", indent=4,
-                 *args, **kwargs):
+                 function_name="Score", *args, **kwargs):
         self.namespace = namespace
         self.class_name = class_name
         self.indent = indent
+        self.function_name = function_name
 
         cg = CSharpCodeGenerator(indent=indent)
         super(CSharpInterpreter, self).__init__(cg, *args, **kwargs)
@@ -34,7 +35,7 @@ class CSharpInterpreter(ToCodeInterpreter, mixins.LinearAlgebraMixin):
         self._cg.reset_state()
         self._reset_reused_expr_cache()
 
-        method_name = "Score"
+        method_name = self.function_name
         args = [(True, self._feature_array_name)]
 
         with self._cg.namespace_definition(self.namespace):

--- a/m2cgen/interpreters/go/interpreter.py
+++ b/m2cgen/interpreters/go/interpreter.py
@@ -20,7 +20,9 @@ class GoInterpreter(ToCodeInterpreter,
     power_function_name = "math.Pow"
     tanh_function_name = "math.Tanh"
 
-    def __init__(self, indent=4, *args, **kwargs):
+    def __init__(self, indent=4, function_name="score", *args, **kwargs):
+        self.function_name = function_name
+
         cg = GoCodeGenerator(indent=indent)
         super(GoInterpreter, self).__init__(cg, *args, **kwargs)
 
@@ -31,7 +33,7 @@ class GoInterpreter(ToCodeInterpreter,
         args = [(True, self._feature_array_name)]
 
         with self._cg.function_definition(
-                name="score",
+                name=self.function_name,
                 args=args,
                 is_scalar_output=expr.output_size == 1):
 

--- a/m2cgen/interpreters/java/interpreter.py
+++ b/m2cgen/interpreters/java/interpreter.py
@@ -31,10 +31,11 @@ class JavaInterpreter(ToCodeInterpreter,
     tanh_function_name = "Math.tanh"
 
     def __init__(self, package_name=None, class_name="Model", indent=4,
-                 *args, **kwargs):
+                 function_name="score", *args, **kwargs):
         self.package_name = package_name
         self.class_name = class_name
         self.indent = indent
+        self.function_name = function_name
 
         # We don't provide any code generator as for each subroutine we will
         # create a new one and concatenate their results into top_cg created
@@ -52,7 +53,7 @@ class JavaInterpreter(ToCodeInterpreter,
             # Since we use SubroutinesAsFunctionsMixin, we already have logic
             # of adding methods. We create first subroutine for incoming
             # expression and call `process_subroutine_queue` method.
-            self.enqueue_subroutine("score", expr)
+            self.enqueue_subroutine(self.function_name, expr)
             self.process_subroutine_queue(top_cg)
 
             if self.with_linear_algebra:

--- a/m2cgen/interpreters/javascript/interpreter.py
+++ b/m2cgen/interpreters/javascript/interpreter.py
@@ -23,9 +23,10 @@ class JavascriptInterpreter(ToCodeInterpreter,
     power_function_name = "Math.pow"
     tanh_function_name = "Math.tanh"
 
-    def __init__(self, indent=4,
+    def __init__(self, indent=4, function_name="score",
                  *args, **kwargs):
         self.indent = indent
+        self.function_name = function_name
 
         cg = JavascriptCodeGenerator(indent=indent)
         super(JavascriptInterpreter, self).__init__(cg, *args, **kwargs)
@@ -37,7 +38,7 @@ class JavascriptInterpreter(ToCodeInterpreter,
         args = [self._feature_array_name]
 
         with self._cg.function_definition(
-                name="score",
+                name=self.function_name,
                 args=args):
             last_result = self._do_interpret(expr)
             self._cg.add_return_statement(last_result)

--- a/m2cgen/interpreters/php/interpreter.py
+++ b/m2cgen/interpreters/php/interpreter.py
@@ -31,7 +31,7 @@ class PhpInterpreter(ToCodeInterpreter, mixins.LinearAlgebraMixin):
         self._reset_reused_expr_cache()
 
         with self._cg.function_definition(
-                name="score",
+                name=self.function_name,
                 args=[(True, self._feature_array_name)]):
             last_result = self._do_interpret(expr)
             self._cg.add_return_statement(last_result)

--- a/m2cgen/interpreters/php/interpreter.py
+++ b/m2cgen/interpreters/php/interpreter.py
@@ -20,7 +20,9 @@ class PhpInterpreter(ToCodeInterpreter, mixins.LinearAlgebraMixin):
     power_function_name = "pow"
     tanh_function_name = "tanh"
 
-    def __init__(self, indent=4, *args, **kwargs):
+    def __init__(self, indent=4, function_name="score", *args, **kwargs):
+        self.function_name = function_name
+
         cg = PhpCodeGenerator(indent=indent)
         super(PhpInterpreter, self).__init__(cg, *args, **kwargs)
 

--- a/m2cgen/interpreters/powershell/interpreter.py
+++ b/m2cgen/interpreters/powershell/interpreter.py
@@ -22,7 +22,9 @@ class PowershellInterpreter(ToCodeInterpreter,
     power_function_name = "[math]::Pow"
     tanh_function_name = "[math]::Tanh"
 
-    def __init__(self, indent=4, *args, **kwargs):
+    def __init__(self, indent=4, function_name="Score", *args, **kwargs):
+        self.function_name = function_name
+
         cg = PowershellCodeGenerator(indent=indent)
         kwargs["feature_array_name"] = "InputVector"
         super(PowershellInterpreter, self).__init__(cg, *args, **kwargs)
@@ -32,7 +34,7 @@ class PowershellInterpreter(ToCodeInterpreter,
         self._reset_reused_expr_cache()
 
         with self._cg.function_definition(
-                name="Score",
+                name=self.function_name,
                 args=[(True, self._feature_array_name)],
                 is_scalar_output=expr.output_size == 1):
             last_result = self._do_interpret(expr)

--- a/m2cgen/interpreters/python/interpreter.py
+++ b/m2cgen/interpreters/python/interpreter.py
@@ -14,7 +14,9 @@ class PythonInterpreter(ToCodeInterpreter,
     power_function_name = "math.pow"
     tanh_function_name = "math.tanh"
 
-    def __init__(self, indent=4, *args, **kwargs):
+    def __init__(self, indent=4, function_name="score", *args, **kwargs):
+        self.function_name = function_name
+
         cg = PythonCodeGenerator(indent=indent)
         super(PythonInterpreter, self).__init__(cg, *args, **kwargs)
 
@@ -23,7 +25,7 @@ class PythonInterpreter(ToCodeInterpreter,
         self._reset_reused_expr_cache()
 
         with self._cg.function_definition(
-                name="score",
+                name=self.function_name,
                 args=[self._feature_array_name]):
             last_result = self._do_interpret(expr)
             self._cg.add_return_statement(last_result)

--- a/m2cgen/interpreters/r/interpreter.py
+++ b/m2cgen/interpreters/r/interpreter.py
@@ -22,15 +22,16 @@ class RInterpreter(ToCodeInterpreter,
     exponent_function_name = "exp"
     tanh_function_name = "tanh"
 
-    def __init__(self, indent=4, *args, **kwargs):
+    def __init__(self, indent=4, function_name="score", *args, **kwargs):
         self.indent = indent
+        self.function_name = function_name
 
         super().__init__(None, *args, **kwargs)
 
     def interpret(self, expr):
         top_cg = self.create_code_generator()
 
-        self.enqueue_subroutine("score", expr)
+        self.enqueue_subroutine(self.function_name, expr)
         self.process_subroutine_queue(top_cg)
 
         return top_cg.code

--- a/m2cgen/interpreters/visual_basic/interpreter.py
+++ b/m2cgen/interpreters/visual_basic/interpreter.py
@@ -21,8 +21,10 @@ class VisualBasicInterpreter(ToCodeInterpreter, mixins.LinearAlgebraMixin):
 
     with_tanh_expr = False
 
-    def __init__(self, module_name="Model", indent=4, *args, **kwargs):
+    def __init__(self, module_name="Model", indent=4, function_name="score",
+                 *args, **kwargs):
         self.module_name = module_name
+        self.function_name = function_name
         cg = VisualBasicCodeGenerator(indent=indent)
         kwargs["feature_array_name"] = "input_vector"
         super(VisualBasicInterpreter, self).__init__(cg, *args, **kwargs)
@@ -32,7 +34,7 @@ class VisualBasicInterpreter(ToCodeInterpreter, mixins.LinearAlgebraMixin):
         self._reset_reused_expr_cache()
 
         args = [(True, self._feature_array_name)]
-        func_name = "score"
+        func_name = self.function_name
 
         with self._cg.function_definition(
                 name=func_name,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from m2cgen import cli
 from tests import utils
 
 
-def _get_mock_args(indent=4, function_name="score", namespace=None,
+def _get_mock_args(indent=4, function_name=None, namespace=None,
                    module_name=None, package_name=None, class_name=None,
                    infile=None, language=None):
     return mock.MagicMock(
@@ -94,6 +94,16 @@ def test_function_name():
     generated_code = cli.generate_code(mock_args).strip()
 
     assert generated_code.startswith("def predict")
+
+
+def test_function_name_csharp_default():
+    infile = _get_pickled_trained_model()
+    mock_args = _get_mock_args(
+        infile=infile, language="c_sharp")
+
+    generated_code = cli.generate_code(mock_args).strip()
+
+    assert 'public static double Score' in generated_code
 
 
 def test_class_name():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,6 +86,16 @@ def test_generate_code():
         expected_output=-47.62913662138064)
 
 
+def test_function_name():
+    infile = _get_pickled_trained_model()
+    mock_args = _get_mock_args(
+        infile=infile, language="python", function_name="predict")
+
+    generated_code = cli.generate_code(mock_args).strip()
+
+    assert generated_code.startswith("def predict")
+
+
 def test_class_name():
     infile = _get_pickled_trained_model()
     mock_args = _get_mock_args(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,13 +10,13 @@ from m2cgen import cli
 from tests import utils
 
 
-def _get_mock_args(indent=4, namespace=None, module_name=None,
-                   package_name=None, class_name=None,
+def _get_mock_args(indent=4, function_name="score", namespace=None,
+                   module_name=None, package_name=None, class_name=None,
                    infile=None, language=None):
     return mock.MagicMock(
-        indent=indent, namespace=namespace, module_name=module_name,
-        package_name=package_name, class_name=class_name,
-        infile=infile, language=language,
+        indent=indent, function_name=function_name, namespace=namespace,
+        module_name=module_name, package_name=package_name,
+        class_name=class_name, infile=infile, language=language,
         recursion_limit=cli.MAX_RECURSION_DEPTH)
 
 


### PR DESCRIPTION
Hello everyone,

First of all, thanks a ton for putting this tool/library together -- especially in resource-stranded environments, it does have a potential to literally save lives!

One small problem I was fighting with while using it was the `score` function it uses in the generated modules. When they are used as drop-in replacements for trained models, using `score` is a bit strange, as the API generally provides function like `predict` or `predict_proba`. It would therefore be of great help to me if this name could be dynamically changed and I would not have to do so manually.

Please do let me know if something like this sounds like a sensible addition. I'd be happy to update the code so that it reflect your vision, so please feel free to just let me know whenever that may be the case.

Thanks!


-------------------------------------------------------

* Currently `m2cgen` generates a module in various languages that has a
  "score"/"Score" function/method. This is not always desirable, as many
  of the trained modules that are to be exported may provide their
  prediction via API functions with different names (such as `predict`).

* This commit adds a way of specifying the name of the function both via
  the CLI and in the exporters (that is, in the `export_to_` funcitons)
  by specifying the `function_name` option/parameter while keeping the
  default set to "score"/"Score" for backwards compatilibity.

Signed-off-by: mr.Shu <mr@shu.io>