### PR TITLE
made language marks long enough

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 env:
   - TEST=API
-  - TEST=E2E LANG="c or python or java or go or javascript or php"
+  - TEST=E2E LANG="c_lang or python or java or go_lang or javascript or php"
   - TEST=E2E LANG="c_sharp or visual_basic or powershell"
   - TEST=E2E LANG="r_lang"
 

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -18,8 +18,8 @@ RECURSION_LIMIT = 5000
 # pytest marks
 PYTHON = pytest.mark.python
 JAVA = pytest.mark.java
-C = pytest.mark.c
-GO = pytest.mark.go
+C = pytest.mark.c_lang
+GO = pytest.mark.go_lang
 JAVASCRIPT = pytest.mark.javascript
 VISUAL_BASIC = pytest.mark.visual_basic
 C_SHARP = pytest.mark.c_sharp


### PR DESCRIPTION
Require that language marks should be at least "standard searchable" 3 symbols length. It allows to use them in different conditions in Travis scripts.