### PR TITLE
Fix #168. Enforce float32 type for split condition values for GBT models created using XGBoost

### DIFF
--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -134,7 +134,7 @@ class XGBoostTreeModelAssembler(BaseTreeBoostingAssembler):
         if "leaf" in tree:
             return ast.NumVal(tree["leaf"])
 
-        threshold = ast.NumVal(np.float32(tree["split_condition"]))
+        threshold = ast.NumVal(tree["split_condition"], dtype=np.float32)
         split = tree["split"]
         feature_idx = self._feature_name_to_idx.get(split, split)
         feature_ref = ast.FeatureRef(feature_idx)

--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -134,7 +134,7 @@ class XGBoostTreeModelAssembler(BaseTreeBoostingAssembler):
         if "leaf" in tree:
             return ast.NumVal(tree["leaf"])
 
-        threshold = ast.NumVal(tree["split_condition"])
+        threshold = ast.NumVal(np.float32(tree["split_condition"]))
         split = tree["split"]
         feature_idx = self._feature_name_to_idx.get(split, split)
         feature_ref = ast.FeatureRef(feature_idx)

--- a/m2cgen/ast.py
+++ b/m2cgen/ast.py
@@ -1,4 +1,3 @@
-import numpy as np
 from enum import Enum
 
 

--- a/m2cgen/ast.py
+++ b/m2cgen/ast.py
@@ -1,3 +1,4 @@
+import numpy as np
 from enum import Enum
 
 
@@ -30,7 +31,9 @@ class NumExpr(Expr):
 
 
 class NumVal(NumExpr):
-    def __init__(self, value):
+    def __init__(self, value, dtype=None):
+        if dtype:
+            value = dtype(value)
         self.value = value
 
     def __str__(self):

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -35,50 +35,51 @@ CLASSIFICATION = pytest.mark.clf
 
 
 # Set of helper functions to make parametrization less verbose.
-def regression(model):
+def regression(model, test_fraction=0.02):
     return (
         model,
-        utils.get_regression_model_trainer(),
+        utils.get_regression_model_trainer(test_fraction),
         REGRESSION,
     )
 
 
-def classification(model):
+def classification(model, test_fraction=0.02):
     return (
         model,
-        utils.get_classification_model_trainer(),
+        utils.get_classification_model_trainer(test_fraction),
         CLASSIFICATION,
     )
 
 
-def classification_binary(model):
+def classification_binary(model, test_fraction=0.02):
     return (
         model,
-        utils.get_binary_classification_model_trainer(),
+        utils.get_binary_classification_model_trainer(test_fraction),
         CLASSIFICATION,
     )
 
 
-def regression_random(model):
+def regression_random(model, test_fraction=0.02):
     return (
         model,
-        utils.get_regression_random_data_model_trainer(0.01),
+        utils.get_regression_random_data_model_trainer(test_fraction),
         REGRESSION,
     )
 
 
-def classification_random(model):
+def classification_random(model, test_fraction=0.02):
     return (
         model,
-        utils.get_classification_random_data_model_trainer(0.01),
+        utils.get_classification_random_data_model_trainer(test_fraction),
         CLASSIFICATION,
     )
 
 
-def classification_binary_random(model):
+def classification_binary_random(model, test_fraction=0.02):
     return (
         model,
-        utils.get_classification_binary_random_data_model_trainer(0.01),
+        utils.get_classification_binary_random_data_model_trainer(
+            test_fraction),
         CLASSIFICATION,
     )
 
@@ -92,6 +93,8 @@ TREE_PARAMS = dict(random_state=RANDOM_SEED)
 FOREST_PARAMS = dict(n_estimators=10, random_state=RANDOM_SEED)
 XGBOOST_PARAMS = dict(base_score=0.6, n_estimators=10,
                       random_state=RANDOM_SEED)
+XGBOOST_HIST_PARAMS = dict(base_score=0.6, n_estimators=10,
+                           tree_method="hist", random_state=RANDOM_SEED)
 XGBOOST_PARAMS_LINEAR = dict(base_score=0.6, n_estimators=10,
                              feature_selector="shuffle", booster="gblinear",
                              random_state=RANDOM_SEED)
@@ -169,6 +172,14 @@ STATSMODELS_LINEAR_REGULARIZED_PARAMS = dict(method="elastic_net",
         regression(xgboost.XGBRegressor(**XGBOOST_PARAMS)),
         classification(xgboost.XGBClassifier(**XGBOOST_PARAMS)),
         classification_binary(xgboost.XGBClassifier(**XGBOOST_PARAMS)),
+
+        # XGBoost (tree method "hist")
+        regression(xgboost.XGBRegressor(**XGBOOST_HIST_PARAMS),
+                   test_fraction=0.2),
+        classification(xgboost.XGBClassifier(**XGBOOST_HIST_PARAMS),
+                       test_fraction=0.2),
+        classification_binary(xgboost.XGBClassifier(**XGBOOST_HIST_PARAMS),
+                              test_fraction=0.2),
 
         # XGBoost (LINEAR)
         regression(xgboost.XGBRegressor(**XGBOOST_PARAMS_LINEAR)),

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,3 +1,4 @@
+import numpy as np
 from m2cgen import ast
 
 
@@ -69,3 +70,9 @@ def test_count_all_exprs_types():
         ast.BinNumOpType.MUL)
 
     assert ast.count_exprs(expr) == 27
+
+
+def test_num_val():
+    assert type(ast.NumVal(1).value) == int
+    assert type(ast.NumVal(1, dtype=np.float32).value) == np.float32
+    assert type(ast.NumVal(1, dtype=np.float64).value) == np.float64


### PR DESCRIPTION
As it turns out the issue reported in https://github.com/BayesWitnesses/m2cgen/issues/168 is not unique to the "hist" tree construction algorithm. It seems that with "hist" method the likelihood of reprdocue is much higher due to relying on feature histograms. I was able to reproduce the same discrepancy with non-hist methods on a larger sample of test data.

The issue occurs due to a double precision error and reproduces every time when the feature value matches the split condition in one of the tree's nodes. 

Example: feature value = `0.671`, split condition = `0.671000004`. When we hit this condition in the generated code the outcome of `0.671 <  0.671000004` is "true" (or "yes" branch). While in XGBoost the same condition leads to the "no" branch.

 After some investigation I noticed that the XGBoost's `DMatrix` forces all values to be `float32` (https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/core.py#L565). At the same time in our assemblers we rely on default 64-bit floats. Forcing the split condition to be `float32` seem to address the issue. At least I couldn't reproduce it so far.
