### PR TITLE
cache handler names

### DIFF
--- a/m2cgen/ast.py
+++ b/m2cgen/ast.py
@@ -1,4 +1,6 @@
 from enum import Enum
+from inspect import getmembers, isclass
+from sys import modules
 
 
 class Expr:
@@ -228,6 +230,9 @@ class IfExpr(CtrlExpr):
     def __str__(self):
         args = ",".join([str(self.test), str(self.body), str(self.orelse)])
         return "IfExpr(" + args + ")"
+
+
+TOTAL_NUMBER_OF_EXPRESSIONS = len(getmembers(modules[__name__], isclass))
 
 
 NESTED_EXPRS_MAPPINGS = [

--- a/m2cgen/interpreters/interpreter.py
+++ b/m2cgen/interpreters/interpreter.py
@@ -1,7 +1,5 @@
-import re
-
 from m2cgen import ast
-from m2cgen.interpreters.utils import CachedResult
+from m2cgen.interpreters.utils import CachedResult, _get_handler_name
 
 
 class BaseInterpreter:
@@ -55,20 +53,11 @@ class BaseInterpreter:
         self._cached_expr_results = {}
 
     def _select_handler(self, expr):
-        handler_name = self._handler_name(type(expr))
+        handler_name = _get_handler_name(type(expr))
         if hasattr(self, handler_name):
             return getattr(self, handler_name)
         raise NotImplementedError(
             "No handler found for '{}'".format(type(expr).__name__))
-
-    @staticmethod
-    def _handler_name(expr_tpe):
-        expr_name = BaseInterpreter._normalize_expr_name(expr_tpe.__name__)
-        return "interpret_" + expr_name
-
-    @staticmethod
-    def _normalize_expr_name(name):
-        return re.sub("(?!^)([A-Z]+)", r"_\1", name).lower()
 
 
 class BaseToCodeInterpreter(BaseInterpreter):

--- a/m2cgen/interpreters/utils.py
+++ b/m2cgen/interpreters/utils.py
@@ -2,6 +2,9 @@ import re
 
 from collections import namedtuple
 from functools import lru_cache
+from math import ceil, log
+
+from m2cgen.ast import TOTAL_NUMBER_OF_EXPRESSIONS
 
 
 CachedResult = namedtuple('CachedResult', ['var_name', 'expr_result'])
@@ -12,7 +15,7 @@ def get_file_content(path):
         return f.read()
 
 
-@lru_cache(maxsize=16)
+@lru_cache(maxsize=1 << ceil(log(TOTAL_NUMBER_OF_EXPRESSIONS, 2)))
 def _get_handler_name(expr_tpe):
     expr_name = _normalize_expr_name(expr_tpe.__name__)
     return "interpret_" + expr_name

--- a/m2cgen/interpreters/utils.py
+++ b/m2cgen/interpreters/utils.py
@@ -1,4 +1,7 @@
+import re
+
 from collections import namedtuple
+from functools import lru_cache
 
 
 CachedResult = namedtuple('CachedResult', ['var_name', 'expr_result'])
@@ -7,3 +10,13 @@ CachedResult = namedtuple('CachedResult', ['var_name', 'expr_result'])
 def get_file_content(path):
     with open(path) as f:
         return f.read()
+
+
+@lru_cache(maxsize=16)
+def _get_handler_name(expr_tpe):
+    expr_name = _normalize_expr_name(expr_tpe.__name__)
+    return "interpret_" + expr_name
+
+
+def _normalize_expr_name(name):
+    return re.sub("(?!^)([A-Z]+)", r"_\1", name).lower()


### PR DESCRIPTION
This method (now function to not overcomplicate the code with handling of two decorators) is used very extensively. So the profit of caching it is obvious.

For example,

```
import sys

from sklearn.datasets import load_boston

import lightgbm as lgb
import m2cgen as m2c

X, y = load_boston(True)
est = lgb.LGBMRegressor(n_estimators=1000, random_state=42).fit(X, y)

sys.setrecursionlimit(int(1e5))
_ = m2c.export_to_python(est)

m2c.interpreters.utils._get_handler_name.cache_info()
```

```
CacheInfo(hits=97666, misses=5, maxsize=16, currsize=5)
```