### PR TITLE
use string buffer to store generated code

### DIFF
--- a/m2cgen/interpreters/c/interpreter.py
+++ b/m2cgen/interpreters/c/interpreter.py
@@ -63,7 +63,7 @@ class CInterpreter(ImperativeToCodeInterpreter,
         if self.with_math_module:
             self._cg.add_dependency("<math.h>")
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()
 
     # Both methods supporting linear algebra do several things:
     #

--- a/m2cgen/interpreters/c/interpreter.py
+++ b/m2cgen/interpreters/c/interpreter.py
@@ -63,7 +63,7 @@ class CInterpreter(ImperativeToCodeInterpreter,
         if self.with_math_module:
             self._cg.add_dependency("<math.h>")
 
-        return self._cg.code
+        return self._cg.get_generated_code()
 
     # Both methods supporting linear algebra do several things:
     #

--- a/m2cgen/interpreters/c_sharp/interpreter.py
+++ b/m2cgen/interpreters/c_sharp/interpreter.py
@@ -58,4 +58,4 @@ class CSharpInterpreter(ImperativeToCodeInterpreter,
         if self.with_math_module:
             self._cg.add_dependency("System.Math")
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()

--- a/m2cgen/interpreters/c_sharp/interpreter.py
+++ b/m2cgen/interpreters/c_sharp/interpreter.py
@@ -58,4 +58,4 @@ class CSharpInterpreter(ImperativeToCodeInterpreter,
         if self.with_math_module:
             self._cg.add_dependency("System.Math")
 
-        return self._cg.code
+        return self._cg.get_generated_code()

--- a/m2cgen/interpreters/code_generator.py
+++ b/m2cgen/interpreters/code_generator.py
@@ -52,7 +52,7 @@ class BaseCodeGenerator:
                 "closing the underlying buffer!\n"
                 "Call reset_state() to allocate new buffer.")
 
-    def get_generated_code(self):
+    def finalize_and_get_generated_code(self):
         if not self._code_buf.closed:
             self._code = self._code_buf.getvalue()
             self._finalize_buffer()

--- a/m2cgen/interpreters/dart/interpreter.py
+++ b/m2cgen/interpreters/dart/interpreter.py
@@ -62,7 +62,7 @@ class DartInterpreter(ImperativeToCodeInterpreter,
         if self.with_math_module:
             self._cg.add_dependency("dart:math")
 
-        return self._cg.code
+        return self._cg.get_generated_code()
 
     def interpret_tanh_expr(self, expr, **kwargs):
         self.with_tanh_expr = True

--- a/m2cgen/interpreters/dart/interpreter.py
+++ b/m2cgen/interpreters/dart/interpreter.py
@@ -62,7 +62,7 @@ class DartInterpreter(ImperativeToCodeInterpreter,
         if self.with_math_module:
             self._cg.add_dependency("dart:math")
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()
 
     def interpret_tanh_expr(self, expr, **kwargs):
         self.with_tanh_expr = True

--- a/m2cgen/interpreters/go/interpreter.py
+++ b/m2cgen/interpreters/go/interpreter.py
@@ -50,4 +50,4 @@ class GoInterpreter(ImperativeToCodeInterpreter,
         if self.with_math_module:
             self._cg.add_dependency("math")
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()

--- a/m2cgen/interpreters/go/interpreter.py
+++ b/m2cgen/interpreters/go/interpreter.py
@@ -50,4 +50,4 @@ class GoInterpreter(ImperativeToCodeInterpreter,
         if self.with_math_module:
             self._cg.add_dependency("math")
 
-        return self._cg.code
+        return self._cg.get_generated_code()

--- a/m2cgen/interpreters/haskell/interpreter.py
+++ b/m2cgen/interpreters/haskell/interpreter.py
@@ -52,7 +52,7 @@ class HaskellInterpreter(ToCodeInterpreter,
         self._cg.prepend_code_line(self._cg.tpl_module_definition(
             module_name=self.module_name))
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()
 
     def interpret_if_expr(self, expr, if_code_gen=None, **kwargs):
         if if_code_gen is None:
@@ -73,7 +73,7 @@ class HaskellInterpreter(ToCodeInterpreter,
 
         if not nested:
             return self._cache_reused_expr(
-                expr, code_gen.get_generated_code())
+                expr, code_gen.finalize_and_get_generated_code())
 
     def interpret_pow_expr(self, expr, **kwargs):
         base_result = self._do_interpret(expr.base_expr, **kwargs)

--- a/m2cgen/interpreters/haskell/interpreter.py
+++ b/m2cgen/interpreters/haskell/interpreter.py
@@ -52,7 +52,7 @@ class HaskellInterpreter(ToCodeInterpreter,
         self._cg.prepend_code_line(self._cg.tpl_module_definition(
             module_name=self.module_name))
 
-        return self._cg.code
+        return self._cg.get_generated_code()
 
     def interpret_if_expr(self, expr, if_code_gen=None, **kwargs):
         if if_code_gen is None:
@@ -72,7 +72,8 @@ class HaskellInterpreter(ToCodeInterpreter,
         code_gen.add_if_termination()
 
         if not nested:
-            return self._cache_reused_expr(expr, code_gen.code)
+            return self._cache_reused_expr(
+                expr, code_gen.get_generated_code())
 
     def interpret_pow_expr(self, expr, **kwargs):
         base_result = self._do_interpret(expr.base_expr, **kwargs)

--- a/m2cgen/interpreters/java/interpreter.py
+++ b/m2cgen/interpreters/java/interpreter.py
@@ -60,7 +60,7 @@ class JavaInterpreter(ImperativeToCodeInterpreter,
                     os.path.dirname(__file__), "linear_algebra.java")
                 top_cg.add_code_lines(utils.get_file_content(filename))
 
-        return top_cg.get_generated_code()
+        return top_cg.finalize_and_get_generated_code()
 
     # Required by SubroutinesMixin to create new code generator for
     # each subroutine.

--- a/m2cgen/interpreters/java/interpreter.py
+++ b/m2cgen/interpreters/java/interpreter.py
@@ -60,7 +60,7 @@ class JavaInterpreter(ImperativeToCodeInterpreter,
                     os.path.dirname(__file__), "linear_algebra.java")
                 top_cg.add_code_lines(utils.get_file_content(filename))
 
-        return top_cg.code
+        return top_cg.get_generated_code()
 
     # Required by SubroutinesMixin to create new code generator for
     # each subroutine.

--- a/m2cgen/interpreters/javascript/interpreter.py
+++ b/m2cgen/interpreters/javascript/interpreter.py
@@ -49,4 +49,4 @@ class JavascriptInterpreter(ImperativeToCodeInterpreter,
                 os.path.dirname(__file__), "linear_algebra.js")
             self._cg.add_code_lines(utils.get_file_content(filename))
 
-        return self._cg.code
+        return self._cg.get_generated_code()

--- a/m2cgen/interpreters/javascript/interpreter.py
+++ b/m2cgen/interpreters/javascript/interpreter.py
@@ -49,4 +49,4 @@ class JavascriptInterpreter(ImperativeToCodeInterpreter,
                 os.path.dirname(__file__), "linear_algebra.js")
             self._cg.add_code_lines(utils.get_file_content(filename))
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()

--- a/m2cgen/interpreters/mixins.py
+++ b/m2cgen/interpreters/mixins.py
@@ -187,7 +187,7 @@ class SubroutinesMixin(BaseToCodeInterpreter):
             last_result = self._do_interpret(subroutine.expr)
             self._cg.add_return_statement(last_result)
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()
 
     def _get_subroutine_name(self):
         subroutine_name = "subroutine" + str(self._subroutine_idx)

--- a/m2cgen/interpreters/mixins.py
+++ b/m2cgen/interpreters/mixins.py
@@ -187,7 +187,7 @@ class SubroutinesMixin(BaseToCodeInterpreter):
             last_result = self._do_interpret(subroutine.expr)
             self._cg.add_return_statement(last_result)
 
-        return self._cg.code
+        return self._cg.get_generated_code()
 
     def _get_subroutine_name(self):
         subroutine_name = "subroutine" + str(self._subroutine_idx)

--- a/m2cgen/interpreters/php/interpreter.py
+++ b/m2cgen/interpreters/php/interpreter.py
@@ -45,4 +45,4 @@ class PhpInterpreter(ImperativeToCodeInterpreter,
 
         self._cg.prepend_code_line("<?php")
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()

--- a/m2cgen/interpreters/php/interpreter.py
+++ b/m2cgen/interpreters/php/interpreter.py
@@ -45,4 +45,4 @@ class PhpInterpreter(ImperativeToCodeInterpreter,
 
         self._cg.prepend_code_line("<?php")
 
-        return self._cg.code
+        return self._cg.get_generated_code()

--- a/m2cgen/interpreters/powershell/interpreter.py
+++ b/m2cgen/interpreters/powershell/interpreter.py
@@ -46,7 +46,7 @@ class PowershellInterpreter(ImperativeToCodeInterpreter,
                 os.path.dirname(__file__), "linear_algebra.ps1")
             self._cg.prepend_code_lines(utils.get_file_content(filename))
 
-        return self._cg.code
+        return self._cg.get_generated_code()
 
     def interpret_exp_expr(self, expr, **kwargs):
         nested_result = self._do_interpret(expr.expr, **kwargs)

--- a/m2cgen/interpreters/powershell/interpreter.py
+++ b/m2cgen/interpreters/powershell/interpreter.py
@@ -46,7 +46,7 @@ class PowershellInterpreter(ImperativeToCodeInterpreter,
                 os.path.dirname(__file__), "linear_algebra.ps1")
             self._cg.prepend_code_lines(utils.get_file_content(filename))
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()
 
     def interpret_exp_expr(self, expr, **kwargs):
         nested_result = self._do_interpret(expr.expr, **kwargs)

--- a/m2cgen/interpreters/python/interpreter.py
+++ b/m2cgen/interpreters/python/interpreter.py
@@ -37,7 +37,7 @@ class PythonInterpreter(ImperativeToCodeInterpreter,
         if self.with_linear_algebra:
             self._cg.add_dependency("numpy", alias="np")
 
-        return self._cg.code
+        return self._cg.get_generated_code()
 
     def interpret_bin_vector_expr(self, expr, **kwargs):
         self.with_linear_algebra = True

--- a/m2cgen/interpreters/python/interpreter.py
+++ b/m2cgen/interpreters/python/interpreter.py
@@ -37,7 +37,7 @@ class PythonInterpreter(ImperativeToCodeInterpreter,
         if self.with_linear_algebra:
             self._cg.add_dependency("numpy", alias="np")
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()
 
     def interpret_bin_vector_expr(self, expr, **kwargs):
         self.with_linear_algebra = True

--- a/m2cgen/interpreters/r/interpreter.py
+++ b/m2cgen/interpreters/r/interpreter.py
@@ -38,7 +38,7 @@ class RInterpreter(ImperativeToCodeInterpreter,
         self.enqueue_subroutine(self.function_name, expr)
         self.process_subroutine_queue(top_cg)
 
-        return top_cg.code
+        return top_cg.get_generated_code()
 
     def create_code_generator(self):
         return RCodeGenerator(indent=self.indent)

--- a/m2cgen/interpreters/r/interpreter.py
+++ b/m2cgen/interpreters/r/interpreter.py
@@ -38,7 +38,7 @@ class RInterpreter(ImperativeToCodeInterpreter,
         self.enqueue_subroutine(self.function_name, expr)
         self.process_subroutine_queue(top_cg)
 
-        return top_cg.get_generated_code()
+        return top_cg.finalize_and_get_generated_code()
 
     def create_code_generator(self):
         return RCodeGenerator(indent=self.indent)

--- a/m2cgen/interpreters/ruby/interpreter.py
+++ b/m2cgen/interpreters/ruby/interpreter.py
@@ -42,7 +42,7 @@ class RubyInterpreter(ImperativeToCodeInterpreter,
                 os.path.dirname(__file__), "linear_algebra.rb")
             self._cg.prepend_code_lines(utils.get_file_content(filename))
 
-        return self._cg.code
+        return self._cg.finalize_and_get_generated_code()
 
     def interpret_bin_num_expr(self, expr, **kwargs):
         if expr.op == ast.BinNumOpType.DIV:

--- a/m2cgen/interpreters/visual_basic/interpreter.py
+++ b/m2cgen/interpreters/visual_basic/interpreter.py
@@ -60,7 +60,7 @@ class VisualBasicInterpreter(ImperativeToCodeInterpreter,
         self._cg.add_code_line(self._cg.tpl_block_termination(
             block_name="Module"))
 
-        return self._cg.get_generated_code()
+        return self._cg.finalize_and_get_generated_code()
 
     def interpret_pow_expr(self, expr, **kwargs):
         base_result = self._do_interpret(expr.base_expr, **kwargs)

--- a/m2cgen/interpreters/visual_basic/interpreter.py
+++ b/m2cgen/interpreters/visual_basic/interpreter.py
@@ -60,7 +60,7 @@ class VisualBasicInterpreter(ImperativeToCodeInterpreter,
         self._cg.add_code_line(self._cg.tpl_block_termination(
             block_name="Module"))
 
-        return self._cg.code
+        return self._cg.get_generated_code()
 
     def interpret_pow_expr(self, expr, **kwargs):
         base_result = self._do_interpret(expr.base_expr, **kwargs)


### PR DESCRIPTION
While changes in #207 are arguably giving significant improvement, the speedup achieved by these updates can be seen on transpiling medium-size models without any profiling tools.

During skimming the report from https://github.com/BayesWitnesses/m2cgen/pull/207#issuecomment-625898131, I noticed that `add_code_line()` takes a huge amount of time (also refer to #209 for another strings-related improvement).

Here is a simple bench.

```
import sys

from sklearn.datasets import load_boston

import lightgbm as lgb
import m2cgen as m2c

X, y = load_boston(True)
est = lgb.LGBMRegressor(n_estimators=1000, random_state=42).fit(X, y)

sys.setrecursionlimit(int(1e5))

%%timeit -n7 -r5
_ = m2c.export_to_python(est)
```

And the results are the following:
```
30.6 s ± 16.9 ms per loop (mean ± std. dev. of 5 runs, 7 loops each)
```
```
2.41 s ± 4.84 ms per loop (mean ± std. dev. of 5 runs, 7 loops each)
```