### PR TITLE
run CI only for master branch and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+if: branch = master
+
 dist: xenial
 
 language: python


### PR DESCRIPTION
This PR eliminates duplicated jobs at CI and saves a lot of time. Now Travis is only triggered for
- `master` branch;
- all PRs to `master`.

One can just comment new added line in config file to test changes for any other branch before submitting a PR.