### PR TITLE
Handle missing values replacement in LightGBM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,3 +50,10 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python${python
     python -m pip install --upgrade pip && \
     pip install --no-cache-dir Cython numpy && \
     pip install --no-cache-dir -r requirements-test.txt
+
+ENV MKL_NUM_THREADS=2
+ENV NUMEXPR_NUM_THREADS=2
+ENV OMP_NUM_THREADS=2
+ENV OPENBLAS_NUM_THREADS=2
+ENV VECLIB_MAXIMUM_THREADS=2
+ENV BLIS_NUM_THREADS=2

--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -317,9 +317,14 @@ class LightGBMModelAssembler(BaseTreeBoostingAssembler):
         op = ast.CompOpType.from_str_op(tree["decision_type"])
         assert op == ast.CompOpType.LTE, "Unexpected comparison op"
 
-        # Make sure that if the "default_left" is true the left tree branch
-        # ends up in the "else" branch of the ast.IfExpr.
-        if tree["default_left"]:
+        missing_type = tree['missing_type']
+
+        if missing_type not in {"NaN", "None"}:
+            raise ValueError(f"Unknown missing_type: {missing_type}")
+
+        reverse_condition = missing_type == "NaN" and tree["default_left"]
+        reverse_condition |= missing_type == "None" and tree["threshold"] >= 0
+        if reverse_condition:
             op = ast.CompOpType.GT
             true_child = tree["right_child"]
             false_child = tree["left_child"]

--- a/tests/assemblers/test_lightgbm.py
+++ b/tests/assemblers/test_lightgbm.py
@@ -133,6 +133,43 @@ def test_regression_random_forest():
     assert utils.cmp_exprs(actual, expected)
 
 
+def test_regression_with_negative_values():
+    estimator = lightgbm.LGBMRegressor(n_estimators=3, random_state=1,
+                                       max_depth=1)
+    utils.get_regression_w_missing_values_model_trainer()(estimator)
+
+    assembler = assemblers.LightGBMModelAssembler(estimator)
+    actual = assembler.assemble()
+
+    expected = ast.BinNumExpr(
+        ast.BinNumExpr(
+            ast.IfExpr(
+                ast.CompExpr(
+                    ast.FeatureRef(8),
+                    ast.NumVal(0.0),
+                    ast.CompOpType.GT),
+                ast.NumVal(155.96889994777868),
+                ast.NumVal(147.72971715548434)),
+            ast.IfExpr(
+                ast.CompExpr(
+                    ast.FeatureRef(2),
+                    ast.NumVal(0.00780560282464346),
+                    ast.CompOpType.GT),
+                ast.NumVal(4.982244683562974),
+                ast.NumVal(-2.978315963345233)),
+            ast.BinNumOpType.ADD),
+        ast.IfExpr(
+            ast.CompExpr(
+                ast.FeatureRef(8),
+                ast.NumVal(-0.0010539205031971832),
+                ast.CompOpType.LTE),
+            ast.NumVal(-3.488666332734598),
+            ast.NumVal(3.670539900363904)),
+        ast.BinNumOpType.ADD)
+
+    assert utils.cmp_exprs(actual, expected)
+
+
 def test_simple_sigmoid_output_transform():
     estimator = lightgbm.LGBMRegressor(n_estimators=2, random_state=1,
                                        max_depth=1, objective="cross_entropy")

--- a/tests/e2e/executors/c.py
+++ b/tests/e2e/executors/c.py
@@ -54,7 +54,7 @@ class CExecutor(base.BaseExecutor):
     def predict(self, X):
 
         exec_args = [os.path.join(self._resource_tmp_dir, self.model_name)]
-        exec_args.extend(map(interpreters.utils.format_float, X))
+        exec_args.extend(map(utils.format_arg, X))
         return utils.predict_from_commandline(exec_args)
 
     def prepare(self):

--- a/tests/e2e/executors/c_sharp.py
+++ b/tests/e2e/executors/c_sharp.py
@@ -49,7 +49,7 @@ class CSharpExecutor(base.BaseExecutor):
 
     def predict(self, X):
         exec_args = [os.path.join(self.target_exec_dir, self.project_name)]
-        exec_args.extend(map(interpreters.utils.format_float, X))
+        exec_args.extend(map(utils.format_arg, X))
         return utils.predict_from_commandline(exec_args)
 
     @classmethod

--- a/tests/e2e/executors/dart.py
+++ b/tests/e2e/executors/dart.py
@@ -42,7 +42,7 @@ class DartExecutor(base.BaseExecutor):
                                  f"{self.executor_name}.dart")
         exec_args = [self._dart,
                      file_name,
-                     *map(interpreters.utils.format_float, X)]
+                     *map(utils.format_arg, X)]
         return utils.predict_from_commandline(exec_args)
 
     def prepare(self):

--- a/tests/e2e/executors/f_sharp.py
+++ b/tests/e2e/executors/f_sharp.py
@@ -35,7 +35,7 @@ class FSharpExecutor(base.BaseExecutor):
 
     def predict(self, X):
         exec_args = [os.path.join(self.target_exec_dir, self.project_name)]
-        exec_args.extend(map(interpreters.utils.format_float, X))
+        exec_args.extend(map(utils.format_arg, X))
         return utils.predict_from_commandline(exec_args)
 
     @classmethod

--- a/tests/e2e/executors/go.py
+++ b/tests/e2e/executors/go.py
@@ -55,7 +55,7 @@ class GoExecutor(base.BaseExecutor):
     def predict(self, X):
 
         exec_args = [os.path.join(self._resource_tmp_dir, self.model_name)]
-        exec_args.extend(map(interpreters.utils.format_float, X))
+        exec_args.extend(map(utils.format_arg, X))
         return utils.predict_from_commandline(exec_args)
 
     def prepare(self):

--- a/tests/e2e/executors/haskell.py
+++ b/tests/e2e/executors/haskell.py
@@ -40,7 +40,7 @@ class HaskellExecutor(base.BaseExecutor):
         app_name = os.path.join(self._resource_tmp_dir,
                                 self.executor_name)
         exec_args = [app_name,
-                     *map(interpreters.utils.format_float, X)]
+                     *map(utils.format_arg, X)]
         return utils.predict_from_commandline(exec_args)
 
     def prepare(self):

--- a/tests/e2e/executors/java.py
+++ b/tests/e2e/executors/java.py
@@ -24,7 +24,7 @@ class JavaExecutor(base.BaseExecutor):
             self._java_bin, "-cp", self._resource_tmp_dir,
             "Executor", "Model", "score"
         ]
-        exec_args.extend(map(m2c.interpreters.utils.format_float, X))
+        exec_args.extend(map(utils.format_arg, X))
         return utils.predict_from_commandline(exec_args)
 
     def prepare(self):

--- a/tests/e2e/executors/javascript.py
+++ b/tests/e2e/executors/javascript.py
@@ -3,6 +3,7 @@ import os
 from py_mini_racer import py_mini_racer
 
 import m2cgen as m2c
+from tests import utils
 from tests.e2e.executors import base
 
 
@@ -17,7 +18,7 @@ class JavascriptExecutor(base.BaseExecutor):
         with open(file_name, 'r') as myfile:
             code = myfile.read()
 
-        args = ",".join(map(m2c.interpreters.utils.format_float, X))
+        args = ",".join(map(utils.format_arg, X))
         caller = f"score([{args}]);\n"
 
         ctx = py_mini_racer.MiniRacer()

--- a/tests/e2e/executors/php.py
+++ b/tests/e2e/executors/php.py
@@ -47,7 +47,8 @@ class PhpExecutor(base.BaseExecutor):
         exec_args = [self._php,
                      "-f",
                      file_name,
-                     *map(interpreters.utils.format_float, X)]
+                     "--",
+                     *map(utils.format_arg, X)]
         return utils.predict_from_commandline(exec_args)
 
     def prepare(self):

--- a/tests/e2e/executors/powershell.py
+++ b/tests/e2e/executors/powershell.py
@@ -40,7 +40,7 @@ class PowershellExecutor(base.BaseExecutor):
                      "-File",
                      file_name,
                      "-InputArray",
-                     ",".join(map(interpreters.utils.format_float, X))]
+                     ",".join(map(utils.format_arg, X))]
         return utils.predict_from_commandline(exec_args)
 
     def prepare(self):

--- a/tests/e2e/executors/r.py
+++ b/tests/e2e/executors/r.py
@@ -34,7 +34,7 @@ class RExecutor(base.BaseExecutor):
         exec_args = [self._r,
                      "--vanilla",
                      file_name,
-                     *map(interpreters.utils.format_float, X)]
+                     *map(utils.format_arg, X)]
         return utils.predict_from_commandline(exec_args)
 
     def prepare(self):

--- a/tests/e2e/executors/ruby.py
+++ b/tests/e2e/executors/ruby.py
@@ -40,7 +40,7 @@ class RubyExecutor(base.BaseExecutor):
                                  f"{self.model_name}.rb")
         exec_args = [self._ruby,
                      file_name,
-                     *map(interpreters.utils.format_float, X)]
+                     *map(utils.format_arg, X)]
         return utils.predict_from_commandline(exec_args)
 
     def prepare(self):

--- a/tests/e2e/executors/visual_basic.py
+++ b/tests/e2e/executors/visual_basic.py
@@ -51,7 +51,7 @@ class VisualBasicExecutor(base.BaseExecutor):
 
     def predict(self, X):
         exec_args = [os.path.join(self.target_exec_dir, self.project_name)]
-        exec_args.extend(map(interpreters.utils.format_float, X))
+        exec_args.extend(map(utils.format_arg, X))
         return utils.predict_from_commandline(exec_args)
 
     @classmethod

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -34,6 +34,8 @@ HASKELL = pytest.mark.haskell
 RUBY = pytest.mark.ruby
 F_SHARP = pytest.mark.f_sharp
 REGRESSION = pytest.mark.regr
+REGRESSION_WITH_MISSING_VALUES = pytest.mark.regr_missing_val
+CLASSIFICATION_WITH_MISSING_VALUES = pytest.mark.clf_missing_val
 CLASSIFICATION = pytest.mark.clf
 
 
@@ -92,6 +94,32 @@ def regression_bounded(model, test_fraction=0.02):
         model,
         utils.get_bounded_regression_model_trainer(test_fraction),
         REGRESSION,
+    )
+
+
+def regression_w_missing_values(model, test_fraction=0.02):
+    return (
+        model,
+        utils.get_regression_w_missing_values_model_trainer(test_fraction),
+        REGRESSION_WITH_MISSING_VALUES,
+    )
+
+
+def classification_random_w_missing_values(model, test_fraction=0.02):
+    return (
+        model,
+        utils.get_classification_random_w_missing_values_model_trainer(
+            test_fraction),
+        CLASSIFICATION_WITH_MISSING_VALUES,
+    )
+
+
+def classification_binary_random_w_missing_values(model, test_fraction=0.02):
+    return (
+        model,
+        utils.get_classification_binary_random_w_missing_values_model_trainer(
+            test_fraction),
+        CLASSIFICATION_WITH_MISSING_VALUES,
     )
 
 
@@ -185,6 +213,14 @@ STATSMODELS_LINEAR_REGULARIZED_PARAMS = dict(method="elastic_net",
             lightgbm.LGBMClassifier(**LIGHTGBM_PARAMS_LARGE)),
         classification_binary_random(
             lightgbm.LGBMClassifier(**LIGHTGBM_PARAMS_LARGE)),
+
+        # LightGBM (Missing values during train)
+        regression_w_missing_values(
+            lightgbm.LGBMRegressor(**LIGHTGBM_PARAMS)),
+        classification_random_w_missing_values(
+            lightgbm.LGBMClassifier(**LIGHTGBM_PARAMS)),
+        classification_binary_random_w_missing_values(
+            lightgbm.LGBMClassifier(**LIGHTGBM_PARAMS)),
 
         # LightGBM (Different Objectives)
         regression(lightgbm.LGBMRegressor(
@@ -549,6 +585,10 @@ STATSMODELS_LINEAR_REGULARIZED_PARAMS = dict(method="elastic_net",
         classification_binary(
             ensemble.RandomForestClassifier(**FOREST_PARAMS)),
     ],
+    [
+        (R, REGRESSION_WITH_MISSING_VALUES),
+        (R, CLASSIFICATION_WITH_MISSING_VALUES),
+    ]
 
     # Following is the list of extra tests for languages/models which are
     # not fully supported yet.


### PR DESCRIPTION
Sometimes exported LGBMRegressor model's prediction doesn't match predictions from the original model. This happens when model encounters values missing during training. More detailed discussion could be found here https://github.com/microsoft/LightGBM/issues/2921 

This is by no means a complete fix for the problem, it only addresses this part of the LightGBM behavior:
"for numerical features, if not missing is seen in training, the missing value will be converted to zero, and then check it with the threshold. So it is not always the left side."

Fix has also being tested on fairly big regression model with numerical features and it works as expected.

How to reproduce:
````
import numpy as np
import lightgbm as lgb
import m2cgen as m2c
from sklearn.datasets import load_diabetes

dataset = load_diabetes()

gbm = lgb.LGBMRegressor(num_leaves=51,
                        learning_rate=0.05,
                        n_estimators=100)
gbm.fit(dataset['data'], dataset['target'])


test = np.array([-2.175, 0.797, np.NaN, 1.193, 0.0, 0.0, 0.0, np.NaN, np.NaN, np.NaN])

print(gbm.predict(np.array([test]))[0])

code = m2c.export_to_python(gbm)

with open('model.py', 'w') as fp:
    fp.write(code)

import model as m

print(m.score(test))
````