### PR TITLE
migrate from OpenJDK to Zulu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,14 @@ FROM ubuntu:bionic
 
 ARG python=3.8
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/zulu-8-amd64
 ENV LC_ALL en_US.UTF-8
 ENV TZ Etc/UTC
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         gpg-agent \
+        dirmngr \
         locales \
         software-properties-common \
         wget \
@@ -17,11 +18,13 @@ RUN apt-get update && \
     echo $TZ > /etc/timezone && \
     locale-gen $LC_ALL && \
     update-locale && \
-    add-apt-repository ppa:deadsnakes/ppa && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
     wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \
     wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
+    add-apt-repository "deb http://repos.azulsystems.com/ubuntu stable main" -y && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
         git \
@@ -32,7 +35,7 @@ RUN apt-get update && \
         python${python}-dev \
         python3-setuptools \
         python3-pip \
-        openjdk-8-jdk \
+        zulu-8 \
         golang-go \
         dotnet-sdk-3.1 \
         powershell \


### PR DESCRIPTION
I remember we had to move to Zulu in LightGBM project due to changed license agreement and limited support. As we are now using our Docker at CI services (and possibly will produce artifacts from it) I think we should do the same.

To be honest, I'm far away from legal aspects of software development, but I believe we should use only things that are totally free and have no pitfalls.

Echoing myself [from the past](https://github.com/microsoft/LightGBM/pull/2170#issue-278245842):
Azul Zulu 
- free to use,
- updated regularly.

I can say that Zulu implementation looks quite stable as there have been no issues with it for more than one year in the LightGBM repo (https://github.com/guolinke/lightgbm-ci-docker/pull/1).

Some refs:
https://azure.microsoft.com/en-us/blog/microsoft-and-azul-systems-bring-free-java-lts-support-to-azure/
https://habr.com/ru/post/448632/