### PR TITLE
support latest Dart 2.12 version

### DIFF
--- a/m2cgen/interpreters/dart/interpreter.py
+++ b/m2cgen/interpreters/dart/interpreter.py
@@ -79,6 +79,13 @@ class DartInterpreter(ImperativeToCodeInterpreter,
             obj=self._do_interpret(expr.expr, **kwargs),
             args=[])
 
+    def interpret_pow_expr(self, expr, **kwargs):
+        pow_result = super().interpret_pow_expr(expr, **kwargs)
+        return self._cg.method_invocation(
+            method_name="toDouble",
+            obj=pow_result,
+            args=[])
+
     def interpret_log1p_expr(self, expr, **kwargs):
         self.with_log1p_expr = True
         return super().interpret_log1p_expr(expr, **kwargs)

--- a/m2cgen/interpreters/dart/linear_algebra.dart
+++ b/m2cgen/interpreters/dart/linear_algebra.dart
@@ -1,12 +1,12 @@
 List<double> addVectors(List<double> v1, List<double> v2) {
-    List<double> result = new List<double>(v1.length);
+    List<double> result = new List<double>.filled(v1.length, 0.0);
     for (int i = 0; i < v1.length; i++) {
         result[i] = v1[i] + v2[i];
     }
     return result;
 }
 List<double> mulVectorNumber(List<double> v1, double num) {
-    List<double> result = new List<double>(v1.length);
+    List<double> result = new List<double>.filled(v1.length, 0.0);
     for (int i = 0; i < v1.length; i++) {
         result[i] = v1[i] * num;
     }

--- a/tests/interpreters/test_dart.py
+++ b/tests/interpreters/test_dart.py
@@ -178,14 +178,14 @@ List<double> score(List<double> input) {
     return addVectors([1.0, 2.0], [3.0, 4.0]);
 }
 List<double> addVectors(List<double> v1, List<double> v2) {
-    List<double> result = new List<double>(v1.length);
+    List<double> result = new List<double>.filled(v1.length, 0.0);
     for (int i = 0; i < v1.length; i++) {
         result[i] = v1[i] + v2[i];
     }
     return result;
 }
 List<double> mulVectorNumber(List<double> v1, double num) {
-    List<double> result = new List<double>(v1.length);
+    List<double> result = new List<double>.filled(v1.length, 0.0);
     for (int i = 0; i < v1.length; i++) {
         result[i] = v1[i] * num;
     }
@@ -208,14 +208,14 @@ List<double> score(List<double> input) {
     return mulVectorNumber([1.0, 2.0], 1.0);
 }
 List<double> addVectors(List<double> v1, List<double> v2) {
-    List<double> result = new List<double>(v1.length);
+    List<double> result = new List<double>.filled(v1.length, 0.0);
     for (int i = 0; i < v1.length; i++) {
         result[i] = v1[i] + v2[i];
     }
     return result;
 }
 List<double> mulVectorNumber(List<double> v1, double num) {
-    List<double> result = new List<double>(v1.length);
+    List<double> result = new List<double>.filled(v1.length, 0.0);
     for (int i = 0; i < v1.length; i++) {
         result[i] = v1[i] * num;
     }
@@ -412,7 +412,7 @@ def test_pow_expr():
     expected_code = """
 import 'dart:math';
 double score(List<double> input) {
-    return pow(2.0, 3.0);
+    return (pow(2.0, 3.0)).toDouble();
 }
 """
 


### PR DESCRIPTION
Release changes: https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#2120---2021-03-03.

- Fix `Error: A value of type 'num' can't be returned from a function with return type 'double'.` for [`pow` function](https://api.dart.dev/stable/2.12.2/dart-math/pow.html). Also, I checked all other functions used in `m2cgen` https://github.com/BayesWitnesses/m2cgen/blob/6b0ede152ac35cdafe8c91b0e54144dfd09efc06/m2cgen/interpreters/dart/interpreter.py#L24-L31 and they all return `double` typed result by default.
- Fix `Error: Can't use the default List constructor.` Refer to https://api.dart.dev/stable/2.12.2/dart-core/List/List.html
   > `@Deprecated("Use a list literal, [], or the List.filled constructor instead")`