### PR TITLE
Rework GitHub workflow to specify only one job as required

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,27 +10,7 @@ on:
 
 jobs:
   test:
-    name: "Python ${{ matrix.python }} API tests"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python:
-          - 3.6
-          - 3.7
-          - 3.8
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 5
-      - name: Build Docker image
-        run: docker build . --file Dockerfile -t m2cgen-docker --build-arg python=${{ matrix.python }}
-      - name: Run API tests
-        run: docker run -v "$GITHUB_WORKSPACE":"/m2cgen" -e TEST=API -e GITHUB_ACTIONS -e GITHUB_RUN_ID -e GITHUB_REF -e GITHUB_REPOSITORY -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} m2cgen-docker bash /m2cgen/.ci/test.sh
-
-  e2e-test:
-    name: "Python ${{ matrix.python }} E2E tests"
+    name: "Python ${{ matrix.python }}, Test: ${{ matrix.lang }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -40,16 +20,40 @@ jobs:
           - 3.7
           - 3.8
         lang:
+          - "API"
           - "c_lang or python or java or go_lang or javascript or php or haskell or ruby"
           - "c_sharp or visual_basic or f_sharp"
           - "r_lang or dart"
           - "powershell"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 5
       - name: Build Docker image
         run: docker build . --file Dockerfile -t m2cgen-docker --build-arg python=${{ matrix.python }}
-      - name: Run E2E tests
-        run: docker run -v "$GITHUB_WORKSPACE":"/m2cgen" -e TEST=E2E -e LANG="${{ matrix.lang }}" m2cgen-docker bash /m2cgen/.ci/test.sh
+      - name: Run tests
+        run: |
+          if [[ "${{ matrix.lang }}" == "API" ]]; then
+            export TEST="API";
+          else
+            export TEST="E2E";
+          fi
+          docker run \
+            -v "$GITHUB_WORKSPACE":"/m2cgen" \
+            -e TEST \
+            -e LANG="${{ matrix.lang }}" \
+            -e GITHUB_ACTIONS \
+            -e GITHUB_RUN_ID \
+            -e GITHUB_REF \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            m2cgen-docker \
+            bash /m2cgen/.ci/test.sh
+  all-successful:
+    # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Note that all tests succeeded
+      run: echo "🎉"


### PR DESCRIPTION
Simply workflow code greatly by deduplicating code of `API` and `E2E` jobs.
Refer to https://github.com/BayesWitnesses/m2cgen/pull/272#issuecomment-663103345 for the initial thoughts why languages were factored out from job names.