### PR TITLE
Increase max line length limit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,8 @@ license-file = LICENSE
 version = m2cgen/VERSION.txt
 
 [flake8]
-exclude = .git,generated_code_examples/,m2cgen/interpreters/python/linear_algebra.py
+max-line-length = 120
+exclude =
+    .git,
+    generated_code_examples/,
+    m2cgen/interpreters/python/linear_algebra.py


### PR DESCRIPTION
Increase max allowed code line length from old-fashioned inconvenient 80 chars to more comfortable 120 chars.