### PR TITLE
Reorganize languages in CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,7 @@ jobs:
           - "c_lang or python or java or go_lang or javascript or php or haskell or ruby"
           - "c_sharp or visual_basic or f_sharp"
           - "r_lang"
-          - "dart"
-          - "powershell"
+          - "dart or powershell"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
           - "API"
           - "c_lang or python or java or go_lang or javascript or php or haskell or ruby"
           - "c_sharp or visual_basic or f_sharp"
-          - "r_lang or dart"
+          - "r_lang"
+          - "dart"
           - "powershell"
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Right now `r_lang or dart` job takes about 3 hours. Moving `dart` to `powershell` (<1h for new combined job) should decrease the overall test time.