### PR TITLE
Improve feature references in split condition for most recent XGBoost versions

### DIFF
--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -155,7 +155,10 @@ class XGBoostTreeModelAssembler(BaseTreeBoostingAssembler):
 
         threshold = ast.NumVal(tree["split_condition"], dtype=np.float32)
         split = tree["split"]
-        feature_idx = self._feature_name_to_idx.get(split, split)
+        if split in self._feature_name_to_idx:
+            feature_idx = self._feature_name_to_idx[split]
+        else:
+            feature_idx = int(split)
         feature_ref = ast.FeatureRef(feature_idx)
 
         # Since comparison with NaN (missing) value always returns false we


### PR DESCRIPTION
In most recent XGBoost versions feature indices can has string type in json model representation.

![image](https://user-images.githubusercontent.com/25141164/115158490-0b98c800-a097-11eb-92b8-a148b46a07d0.png)
