### PR TITLE
Bump numpy from 1.19.2 to 1.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,10 @@ WORKDIR /m2cgen
 COPY requirements-test.txt ./
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python${python} 1 && \
     python -m pip install --upgrade pip && \
-    pip install --no-cache-dir Cython "numpy==1.19.2" && \
+    pip install --no-cache-dir Cython && \
+    if [[ "$python" == "3.6" ]]; then \
+        pip install --no-cache-dir "numpy==1.19.5"; \
+    else \
+        pip install --no-cache-dir "numpy==1.20.2"; \
+    fi && \
     pip install --no-cache-dir -r requirements-test.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ COPY requirements-test.txt ./
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python${python} 1 && \
     python -m pip install --upgrade pip && \
     pip install --no-cache-dir Cython && \
-    if [[ "$python" = "3.6" ]]; then \
+    if [ "$python" = "3.6" ]; then \
         pip install --no-cache-dir "numpy==1.19.5"; \
     else \
         pip install --no-cache-dir "numpy==1.20.2"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ COPY requirements-test.txt ./
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python${python} 1 && \
     python -m pip install --upgrade pip && \
     pip install --no-cache-dir Cython && \
-    if [[ "$python" == "3.6" ]]; then \
+    if [[ "$python" = "3.6" ]]; then \
         pip install --no-cache-dir "numpy==1.19.5"; \
     else \
         pip install --no-cache-dir "numpy==1.20.2"; \

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,6 +12,6 @@ pytest-mock==3.5.1
 pytest-cov==2.11.1
 
 # Other stuff
-numpy==1.19.2
+numpy==1.20.2
 scipy==1.5.2
 py-mini-racer==0.5.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,6 +12,7 @@ pytest-mock==3.5.1
 pytest-cov==2.11.1
 
 # Other stuff
-numpy==1.20.2
+numpy==1.20.2; python_version > "3.6"
+numpy==1.19.5; python_version <= "3.6"
 scipy==1.5.2
 py-mini-racer==0.5.0


### PR DESCRIPTION
Supersede broken #357.

Support for Python 3.6 was dropped in Numpy 1.20 release.

> The Python versions supported for this release are 3.7-3.9, support for Python 3.6 has been dropped.
   https://github.com/numpy/numpy/blob/main/doc/source/release/1.20.0-notes.rst#numpy-1200-release-notes