### PR TITLE
Bump lightning version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@ scikit-learn==0.24.1
 xgboost==1.4.1
 lightgbm==3.2.1
 statsmodels==0.12.2
-git+git://github.com/scikit-learn-contrib/lightning.git@e1d7a405c8f4f547c3bc507b2ad1cd8867ec2625
+git+git://github.com/scikit-learn-contrib/lightning.git@refs/pull/154/merge
 
 # Testing tools
 flake8==3.9.1


### PR DESCRIPTION
Current master cannot be installed with Python 3.9.

https://github.com/scikit-learn-contrib/lightning/pull/154

Needed by #371.