### PR TITLE
Bump lightning version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,10 +61,4 @@ WORKDIR /m2cgen
 COPY requirements-test.txt ./
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python${python} 1 && \
     python -m pip install --upgrade pip && \
-    pip install --no-cache-dir Cython && \
-    if [ "$python" = "3.6" ]; then \
-        pip install --no-cache-dir "numpy==1.19.5"; \
-    else \
-        pip install --no-cache-dir "numpy==1.21.0"; \
-    fi && \
     pip install --no-cache-dir -r requirements-test.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@ scikit-learn==0.24.2
 xgboost==1.4.2
 lightgbm==3.2.1
 statsmodels==0.12.2
-git+git://github.com/scikit-learn-contrib/lightning.git@3393a272ca64ee71563b8f887e5fbc4fbe0a54ed
+sklearn-contrib-lightning==0.6.1
 
 # Testing tools
 flake8==3.9.2


### PR DESCRIPTION
`lightning` has started to provide compiled wheel files recently. So we don't need to install from sources.