### PR TITLE
Move resource allocations for CLI tests in pytest fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
-import pytest
+import io
+import pickle
 
-from tests.utils import tmp_dir
+import pytest
+from sklearn.linear_model import LinearRegression
+
+from tests.utils import get_regression_model_trainer, tmp_dir
 
 
 def pytest_addoption(parser):
@@ -19,3 +23,24 @@ def is_fast(request):
 def global_tmp_dir():
     with tmp_dir() as directory:
         yield directory
+
+
+@pytest.fixture(scope="module")
+def trained_model():
+    estimator = LinearRegression()
+    return get_regression_model_trainer()(estimator)[2]
+
+
+@pytest.fixture
+def pickled_model(trained_model):
+    infile = io.BytesIO()
+    pickle.dump(trained_model, infile)
+    infile.seek(0)
+    return infile
+
+
+@pytest.fixture(scope="module")
+def path_to_pickled_model(global_tmp_dir, trained_model):
+    p = global_tmp_dir / "model.pickle"
+    p.write_bytes(pickle.dumps(trained_model))
+    return p

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -1,56 +1,39 @@
-import pickle
 import subprocess
 from platform import system
 
 import pytest
-from sklearn.linear_model import LinearRegression
 
-from tests import utils
+from tests.utils import verify_python_model_is_expected
 
 
 def execute_test(exec_args):
     result = subprocess.Popen(" ".join(exec_args), stdout=subprocess.PIPE, shell=True)
     generated_code = result.stdout.read().decode("utf-8")
 
-    utils.verify_python_model_is_expected(
+    verify_python_model_is_expected(
         generated_code,
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
         expected_output=-47.62913662138064)
 
 
-def _prepare_pickled_model(tmp_path):
-    p = tmp_path / "model.pickle"
-
-    estimator = LinearRegression()
-    utils.get_regression_model_trainer()(estimator)
-
-    p.write_bytes(pickle.dumps(estimator))
-
-    return p
-
-
-def test_positional_arg(tmp_path):
-    pickled_model_path = _prepare_pickled_model(tmp_path)
-    exec_args = ["m2cgen", "--language", "python", str(pickled_model_path)]
+def test_positional_arg(path_to_pickled_model):
+    exec_args = ["m2cgen", "--language", "python", str(path_to_pickled_model)]
     execute_test(exec_args)
 
 
-def test_override_input(tmp_path):
-    pickled_model_path = _prepare_pickled_model(tmp_path)
-    exec_args = ["m2cgen", "--language", "python", "<", str(pickled_model_path)]
+def test_override_input(path_to_pickled_model):
+    exec_args = ["m2cgen", "--language", "python", "<", str(path_to_pickled_model)]
     execute_test(exec_args)
 
 
-def test_piped(tmp_path):
-    pickled_model_path = _prepare_pickled_model(tmp_path)
+def test_piped(path_to_pickled_model):
     exec_args = [
         "type" if system() in {'Windows', 'Microsoft'} else "cat",
-        str(pickled_model_path), " | ", "m2cgen", "--language", "python"]
+        str(path_to_pickled_model), "|", "m2cgen", "--language", "python"]
     execute_test(exec_args)
 
 
 @pytest.mark.skip(reason="utils.verify_python_model_is_expected doesn't support modules")
-def test_dash_m(tmp_path):
-    pickled_model_path = _prepare_pickled_model(tmp_path)
-    exec_args = ["python", "-m", "m2cgen", "--language", "python", str(pickled_model_path)]
+def test_dash_m(path_to_pickled_model):
+    exec_args = ["python", "-m", "m2cgen", "--language", "python", str(path_to_pickled_model)]
     execute_test(exec_args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,7 +80,7 @@ def test_generate_code(pickled_model):
         expected_output=-44.40540274041321)
 
 
-def test_function_name(pickled_model):pickled_model
+def test_function_name(pickled_model):
     mock_args = _get_mock_args(infile=pickled_model, language="python", function_name="predict")
     generated_code = cli.generate_code(mock_args).strip()
 


### PR DESCRIPTION
Fixtures with `scope="module"` allow to save some time by executing their code once per test module instead of running that code in each test function as previously.