### PR TITLE
Ignore Python files with math functions in calculating code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,3 +9,7 @@ coverage:
         informational: false
         only_pulls: false
 comment: false
+ignore:
+  - "m2cgen/interpreters/python/linear_algebra.py"
+  - "m2cgen/interpreters/python/sigmoid.py"
+  - "m2cgen/interpreters/python/softmax.py"


### PR DESCRIPTION
Content of these files is already used in Python interpreter tests, e.g. here
https://github.com/BayesWitnesses/m2cgen/blob/975d8176953a07c826572350d9fdbfb6c6960ca5/tests/interpreters/test_python.py#L446-L461

Increase code coverage. 