### PR TITLE
Add test for unknown model in statsmodels

### DIFF
--- a/m2cgen/assemblers/linear.py
+++ b/m2cgen/assemblers/linear.py
@@ -17,12 +17,10 @@ class BaseLinearModelAssembler(ModelAssembler):
         intercept = utils.to_1d_array(self._get_intercept())
 
         if coef.shape[0] == 1:
-            return self._final_transform(
-                _linear_to_ast(coef[0], intercept[0]))
+            return self._final_transform(_linear_to_ast(coef[0], intercept[0]))
 
         exprs = [
-            self._final_transform(
-                _linear_to_ast(coef[idx], intercept[idx]))
+            self._final_transform(_linear_to_ast(coef[idx], intercept[idx]))
             for idx in range(coef.shape[0])
         ]
         return ast.VectorVal(exprs)
@@ -40,8 +38,7 @@ class BaseLinearModelAssembler(ModelAssembler):
 class SklearnLinearModelAssembler(BaseLinearModelAssembler):
 
     def _get_intercept(self):
-        return getattr(self.model, "intercept_",
-                       np.zeros(self._get_coef().shape[0]))
+        return getattr(self.model, "intercept_", np.zeros(self._get_coef().shape[0]))
 
     def _get_coef(self):
         return self.model.coef_
@@ -85,8 +82,7 @@ class GLMMixin:
         link_function_lower = link_function.lower()
         supported_inversed_funs = self._get_supported_inversed_funs()
         if link_function_lower not in supported_inversed_funs:
-            raise ValueError(
-                f"Unsupported link function '{link_function}'")
+            raise ValueError(f"Unsupported link function '{link_function}'")
         fun = supported_inversed_funs[link_function_lower]
         return fun(ast_to_transform)
 
@@ -198,14 +194,15 @@ class StatsmodelsModelAssemblerSelector(ModelAssembler):
         underlying_model = type(model.model).__name__
         if underlying_model == "GLM":
             self.assembler = StatsmodelsGLMModelAssembler(model)
-        elif underlying_model in {"GLS",
-                                  "GLSAR",
-                                  "OLS",
-                                  "WLS"}:
+        elif underlying_model in {
+            "GLS",
+            "GLSAR",
+            "OLS",
+            "WLS"
+        }:
             self.assembler = StatsmodelsLinearModelAssembler(model)
         else:
-            raise NotImplementedError(
-                f"Model '{underlying_model}' is not supported")
+            raise NotImplementedError(f"Model '{underlying_model}' is not supported")
 
     def assemble(self):
         return self.assembler.assemble()

--- a/tests/assemblers/test_linear.py
+++ b/tests/assemblers/test_linear.py
@@ -292,10 +292,8 @@ def test_statsmodels_unknown_underlying_model():
     estimator = utils.StatsmodelsSklearnLikeWrapper(ValidGLS, {})
     _, __, estimator = utils.get_regression_model_trainer()(estimator)
 
-    assembler = assemblers.StatsmodelsModelAssemblerSelector(estimator)
-
     with pytest.raises(NotImplementedError, match="Model 'ValidGLS' is not supported"):
-        assembler.assemble()
+        assemblers.StatsmodelsModelAssemblerSelector(estimator)
 
 
 def test_statsmodels_processmle():

--- a/tests/assemblers/test_linear.py
+++ b/tests/assemblers/test_linear.py
@@ -274,15 +274,28 @@ def test_statsmodels_w_const():
     assert utils.cmp_exprs(actual, expected)
 
 
-@pytest.mark.xfail(raises=ValueError, strict=True)
 def test_statsmodels_unknown_constant_position():
     estimator = utils.StatsmodelsSklearnLikeWrapper(
         sm.GLS,
         dict(init=dict(hasconst=True)))
     _, __, estimator = utils.get_regression_model_trainer()(estimator)
 
+    with pytest.raises(ValueError, match="Unknown constant position"):
+        assemblers.StatsmodelsModelAssemblerSelector(estimator)
+
+
+def test_statsmodels_unknown_underlying_model():
+
+    class ValidGLS(sm.GLS):
+        pass
+
+    estimator = utils.StatsmodelsSklearnLikeWrapper(ValidGLS, {})
+    _, __, estimator = utils.get_regression_model_trainer()(estimator)
+
     assembler = assemblers.StatsmodelsModelAssemblerSelector(estimator)
-    assembler.assemble()
+
+    with pytest.raises(NotImplementedError, match="Model 'ValidGLS' is not supported"):
+        assembler.assemble()
 
 
 def test_statsmodels_processmle():
@@ -689,7 +702,6 @@ def test_statsmodels_glm_cauchy_link_func():
     assert utils.cmp_exprs(actual, expected)
 
 
-@pytest.mark.xfail(raises=ValueError, strict=True)
 def test_statsmodels_glm_unknown_link_func():
 
     class ValidPowerLink(sm.families.links.Power):
@@ -703,7 +715,9 @@ def test_statsmodels_glm_unknown_link_func():
     estimator = estimator.fit([[1], [2]], [0.1, 0.2])
 
     assembler = assemblers.StatsmodelsModelAssemblerSelector(estimator)
-    assembler.assemble()
+
+    with pytest.raises(ValueError, match="Unsupported link function 'ValidPowerLink'"):
+        assembler.assemble()
 
 
 def test_sklearn_glm_identity_link_func():
@@ -743,13 +757,18 @@ def test_sklearn_glm_log_link_func():
     assert utils.cmp_exprs(actual, expected)
 
 
-@pytest.mark.xfail(raises=ValueError, strict=True)
 def test_sklearn_glm_unknown_link_func():
-    estimator = linear_model.TweedieRegressor(power=1, link="this_link_func_does_not_exist", max_iter=10)
+
+    class ValidIdentityLink(linear_model._glm.link.IdentityLink):
+        pass
+
+    estimator = linear_model.TweedieRegressor(power=2, link=ValidIdentityLink(), max_iter=10)
     estimator = estimator.fit([[1], [2]], [0.1, 0.2])
 
     assembler = assemblers.SklearnGLMModelAssembler(estimator)
-    assembler.assemble()
+
+    with pytest.raises(ValueError, match="Unsupported link function 'ValidIdentityLink'"):
+        assembler.assemble()
 
 
 def test_lightning_regression():

--- a/tests/assemblers/test_linear.py
+++ b/tests/assemblers/test_linear.py
@@ -762,7 +762,7 @@ def test_sklearn_glm_unknown_link_func():
     class ValidIdentityLink(linear_model._glm.link.IdentityLink):
         pass
 
-    estimator = linear_model.TweedieRegressor(power=2, link=ValidIdentityLink(), max_iter=10)
+    estimator = linear_model.TweedieRegressor(power=1, link=ValidIdentityLink(), max_iter=10)
     estimator = estimator.fit([[1], [2]], [0.1, 0.2])
 
     assembler = assemblers.SklearnGLMModelAssembler(estimator)


### PR DESCRIPTION
Increase code coverage.

Also, convert `@pytest.mark.xfail` into `pytest.raises` because `xfail` is mostly for
> known bugs or missing features.
    https://docs.pytest.org/en/latest/reference/reference.html#pytest-xfail

`pytest.raises` makes tests more precise. Also, error message cannot be specified in `xfail`.