### PR TITLE
Update error type in FAQ about recursion error

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ $ cat <pickle_file> | m2cgen --language <language>
 ```
 
 ## FAQ
-**Q: Generation fails with `RuntimeError: maximum recursion depth exceeded` error.**
+**Q: Generation fails with `RecursionError: maximum recursion depth exceeded` error.**
 
 A: If this error occurs while generating code using an ensemble model, try to reduce the number of trained estimators within that model. Alternatively you can increase the maximum recursion depth with `sys.setrecursionlimit(<new_depth>)`.
 


### PR DESCRIPTION
Starting from Python 3.5 `RecursionError` is raised instead of plain `RuntimeError`.
> New in version 3.5: Previously, a plain `RuntimeError` was raised.
   https://docs.python.org/3/library/exceptions.html#RecursionError
   https://docs.python.org/3/library/sys.html#sys.setrecursionlimit