### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 * [FAQ](#faq)
 
 ## Installation
-Supported Python version is >= **3.6**.
+Supported Python version is >= **3.7**.
 ```
 pip install m2cgen
 ```

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,10 +1,8 @@
 # Supported models
-scikit-learn==1.0.2; python_version > "3.6"
-scikit-learn==0.24.2; python_version <= "3.6"
+scikit-learn==1.0.2
 xgboost==1.4.2
 lightgbm==3.3.2
-statsmodels==0.13.1; python_version > "3.6"
-statsmodels==0.12.2; python_version <= "3.6"
+statsmodels==0.13.1
 sklearn-contrib-lightning==0.6.1
 
 # Testing tools
@@ -16,7 +14,5 @@ pytest-cov==3.0.0
 py-mini-racer==0.6.0
 
 # Other stuff
-numpy==1.21.5; python_version > "3.6"
-numpy==1.19.5; python_version <= "3.6"
-scipy==1.7.3; python_version > "3.6"
-scipy==1.5.4; python_version <= "3.6"
+numpy==1.21.5
+scipy==1.7.3

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -34,7 +33,7 @@ setup(
     keywords=("sklearn statsmodels lightning xgboost lightgbm "
               "machine-learning ml regression classification "
               "transpilation code-generation"),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "numpy",
     ],

--- a/tests/e2e/executors/powershell.py
+++ b/tests/e2e/executors/powershell.py
@@ -30,7 +30,7 @@ class PowershellExecutor(BaseExecutor):
         assembler_cls = get_assembler_cls(model)
         self.model_ast = assembler_cls(model).assemble()
 
-        self._powershell = "powershell" if system() in {'Windows', 'Microsoft'} else "pwsh"
+        self._powershell = "powershell" if system() == "Windows" else "pwsh"
 
         self.script_path = None
 

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -25,7 +25,7 @@ def test_override_input(path_to_pickled_model):
 
 def test_piped(path_to_pickled_model):
     exec_args = [
-        "type" if system() in {'Windows', 'Microsoft'} else "cat",
+        "type" if system() == "Windows" else "cat",
         str(path_to_pickled_model), "|", "m2cgen", "--language", "python"]
     execute_test(exec_args)
 


### PR DESCRIPTION
Python 3.6 reached its End of Life in December 2021 and there is no need to support it anymore.
https://devguide.python.org/devcycle/#security-branches