### PR TITLE
Improve feature references in split condition for most recent XGBoost versions

### DIFF
--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -155,6 +155,8 @@ class XGBoostTreeModelAssembler(BaseTreeBoostingAssembler):
         split = tree["split"]
         if split in self._feature_name_to_idx:
             feature_idx = self._feature_name_to_idx[split]
+        elif split[0] == "f":
+            feature_idx = int(split[1:])
         else:
             feature_idx = int(split)
         feature_ref = ast.FeatureRef(feature_idx)


### PR DESCRIPTION
For versions prior 1.4, default feature names are indices prefixed with `f` in XGBoost model dump. `feature_names` property correctly returns list of such strings, e.g. `["f0", "f1", "f2", "f3"]`.

For versions 1.4 - 1.5, default feature names are just indices in XGBoost model dump (refer to #380). `feature_names` property is `None`.

Starting from 1.5 version, default feature names are indices prefixed with `f` in XGBoost model dump. `feature_names` property is `None`.


![image](https://user-images.githubusercontent.com/25141164/152246250-c7857a30-49bb-4282-b72e-ce4e64435686.png)
