### PR TITLE
Significantly reduce the number of redundant parentheses in the generated code

### DIFF
--- a/m2cgen/ast.py
+++ b/m2cgen/ast.py
@@ -7,6 +7,7 @@ import numpy as np
 
 class Expr:
     output_size = 1
+    precedence = None
     # Setting this value to true serves as an indication that the result
     # of evaluation of this expression is being used in other expressions
     # and it's recommended to persist or cache it in some way.
@@ -206,6 +207,8 @@ class TanhExpr(NumExpr):
 
 
 class PowExpr(NumExpr):
+    precedence = 4
+
     def __init__(self, base_expr, exp_expr, to_reuse=False):
         assert base_expr.output_size == 1, "Only scalars are supported"
         assert exp_expr.output_size == 1, "Only scalars are supported"
@@ -243,6 +246,7 @@ class BinNumExpr(NumExpr, BinExpr):
         self.right = right
         self.op = op
         self.to_reuse = to_reuse
+        self.precedence = 3 if op in (BinNumOpType.MUL, BinNumOpType.DIV) else 2
 
     def __str__(self):
         return (f"BinNumExpr({self.left},{self.right},{self.op.name},"
@@ -372,6 +376,8 @@ COMP_OP_TYPE_MAPPING = {e.value: e for e in CompOpType}
 
 
 class CompExpr(BoolExpr):
+    precedence = 1
+
     def __init__(self, left, right, op):
         assert left.output_size == 1, "Only scalars are supported"
         assert right.output_size == 1, "Only scalars are supported"

--- a/m2cgen/interpreters/code_generator.py
+++ b/m2cgen/interpreters/code_generator.py
@@ -99,10 +99,11 @@ class BaseCodeGenerator:
             lines = lines.strip().split(new_line)
         self._write_to_code_buffer(f"{new_line.join(lines)}{new_line}", prepend=True)
 
-    # Following methods simply compute expressions using templates without changing result.
+    def infix_expression(self, left, right, op, wrap=False):
+        result = self.tpl_infix_expression(left=left, right=right, op=op)
+        return result if not wrap else f"({result})"
 
-    def infix_expression(self, left, right, op):
-        return self.tpl_infix_expression(left=left, right=right, op=op)
+    # Following methods simply compute expressions using templates without changing result.
 
     def num_value(self, value):
         return self.tpl_num_value(value=value)
@@ -188,7 +189,7 @@ class CLikeCodeGenerator(ImperativeCodeGenerator):
     """
 
     tpl_num_value = CodeTemplate("{value}")
-    tpl_infix_expression = CodeTemplate("({left}) {op} ({right})")
+    tpl_infix_expression = CodeTemplate("{left} {op} {right}")
     tpl_var_declaration = CodeTemplate("{var_type} {var_name};")
     tpl_return_statement = CodeTemplate("return {value};")
     tpl_array_index_access = CodeTemplate("{array_name}[{index}]")

--- a/m2cgen/interpreters/elixir/code_generator.py
+++ b/m2cgen/interpreters/elixir/code_generator.py
@@ -9,7 +9,7 @@ class ElixirCodeGenerator(FunctionalCodeGenerator):
     tpl_else_statement = CodeTemplate("true ->")
     tpl_num_value = CodeTemplate("{value}")
     tpl_block_termination = CodeTemplate("end")
-    tpl_infix_expression = CodeTemplate("({left}) {op} ({right})")
+    tpl_infix_expression = CodeTemplate("{left} {op} {right}")
     tpl_module_definition = CodeTemplate("""defmodule {module_name} do
     @compile {{:inline, read: 2}}
     defp read(bin, pos) do

--- a/m2cgen/interpreters/f_sharp/code_generator.py
+++ b/m2cgen/interpreters/f_sharp/code_generator.py
@@ -9,7 +9,7 @@ class FSharpCodeGenerator(FunctionalCodeGenerator):
     tpl_if_statement = CodeTemplate("if {if_def} then")
     tpl_else_statement = CodeTemplate("else")
     tpl_num_value = CodeTemplate("{value}")
-    tpl_infix_expression = CodeTemplate("({left}) {op} ({right})")
+    tpl_infix_expression = CodeTemplate("{left} {op} {right}")
     tpl_array_index_access = CodeTemplate("{array_name}.[{index}]")
 
     def add_if_termination(self):

--- a/m2cgen/interpreters/f_sharp/interpreter.py
+++ b/m2cgen/interpreters/f_sharp/interpreter.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from m2cgen.ast import BinNumOpType
+from m2cgen.ast import BinNumOpType, PowExpr
 from m2cgen.interpreters.f_sharp.code_generator import FSharpCodeGenerator
 from m2cgen.interpreters.interpreter import FunctionalToCodeInterpreter
 from m2cgen.interpreters.mixins import BinExpressionDepthTrackingMixin, LinearAlgebraMixin
@@ -10,6 +10,8 @@ from m2cgen.interpreters.utils import get_file_content
 class FSharpInterpreter(FunctionalToCodeInterpreter,
                         LinearAlgebraMixin,
                         BinExpressionDepthTrackingMixin):
+
+    infix_expressions = [*FunctionalToCodeInterpreter.infix_expressions, PowExpr]
 
     # Too long lines causes F# compiler to crash with
     # error FS0193 : internal error :
@@ -81,11 +83,15 @@ class FSharpInterpreter(FunctionalToCodeInterpreter,
     def create_code_generator(self):
         return FSharpCodeGenerator(indent=self.indent)
 
-    def interpret_pow_expr(self, expr, **kwargs):
-        base_result = self._do_interpret(expr.base_expr, **kwargs)
-        exp_result = self._do_interpret(expr.exp_expr, **kwargs)
+    def interpret_pow_expr(self, expr, left_precedence=None,
+                           right_precedence=None, **kwargs):
+        base_result = self._do_interpret(
+            expr.base_expr, left_precedence=expr.precedence, **kwargs)
+        exp_result = self._do_interpret(
+            expr.exp_expr, right_precedence=expr.precedence, **kwargs)
         return self._cg.infix_expression(
-            left=base_result, right=exp_result, op="**")
+            left=base_result, right=exp_result, op="**",
+            wrap=self._wrap_infix_expr(expr, left_precedence, right_precedence))
 
     def interpret_log1p_expr(self, expr, **kwargs):
         self.with_log1p_expr = True

--- a/m2cgen/interpreters/go/code_generator.py
+++ b/m2cgen/interpreters/go/code_generator.py
@@ -5,7 +5,7 @@ from m2cgen.interpreters.code_generator import CodeTemplate, ImperativeCodeGener
 
 class GoCodeGenerator(ImperativeCodeGenerator):
     tpl_num_value = CodeTemplate("{value}")
-    tpl_infix_expression = CodeTemplate("({left}) {op} ({right})")
+    tpl_infix_expression = CodeTemplate("{left} {op} {right}")
     tpl_array_index_access = CodeTemplate("{array_name}[{index}]")
     tpl_else_statement = CodeTemplate("}} else {{")
     tpl_block_termination = CodeTemplate("}}")

--- a/m2cgen/interpreters/haskell/code_generator.py
+++ b/m2cgen/interpreters/haskell/code_generator.py
@@ -9,7 +9,7 @@ class HaskellCodeGenerator(FunctionalCodeGenerator):
     tpl_if_statement = CodeTemplate("if {if_def} then")
     tpl_else_statement = CodeTemplate("else")
     tpl_num_value = CodeTemplate("{value}")
-    tpl_infix_expression = CodeTemplate("({left}) {op} ({right})")
+    tpl_infix_expression = CodeTemplate("{left} {op} {right}")
     tpl_module_definition = CodeTemplate("module {module_name} where")
 
     def array_index_access(self, array_name, index):

--- a/m2cgen/interpreters/haskell/interpreter.py
+++ b/m2cgen/interpreters/haskell/interpreter.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from m2cgen.ast import BinNumOpType
+from m2cgen.ast import BinNumOpType, PowExpr
 from m2cgen.interpreters.haskell.code_generator import HaskellCodeGenerator
 from m2cgen.interpreters.interpreter import FunctionalToCodeInterpreter
 from m2cgen.interpreters.mixins import LinearAlgebraMixin
@@ -9,6 +9,9 @@ from m2cgen.interpreters.utils import get_file_content
 
 class HaskellInterpreter(FunctionalToCodeInterpreter,
                          LinearAlgebraMixin):
+
+    infix_expressions = [*FunctionalToCodeInterpreter.infix_expressions, PowExpr]
+
     supported_bin_vector_ops = {
         BinNumOpType.ADD: "addVectors",
     }
@@ -80,11 +83,15 @@ class HaskellInterpreter(FunctionalToCodeInterpreter,
     def create_code_generator(self):
         return HaskellCodeGenerator(indent=self.indent)
 
-    def interpret_pow_expr(self, expr, **kwargs):
-        base_result = self._do_interpret(expr.base_expr, **kwargs)
-        exp_result = self._do_interpret(expr.exp_expr, **kwargs)
+    def interpret_pow_expr(self, expr, left_precedence=None,
+                           right_precedence=None, **kwargs):
+        base_result = self._do_interpret(
+            expr.base_expr, left_precedence=expr.precedence, **kwargs)
+        exp_result = self._do_interpret(
+            expr.exp_expr, right_precedence=expr.precedence, **kwargs)
         return self._cg.infix_expression(
-            left=base_result, right=exp_result, op="**")
+            left=base_result, right=exp_result, op="**",
+            wrap=self._wrap_infix_expr(expr, left_precedence, right_precedence))
 
     def interpret_log1p_expr(self, expr, **kwargs):
         self.with_log1p_expr = True

--- a/m2cgen/interpreters/interpreter.py
+++ b/m2cgen/interpreters/interpreter.py
@@ -1,9 +1,12 @@
 from m2cgen.assemblers import fallback_expressions
-from m2cgen.ast import IfExpr
+from m2cgen.ast import IfExpr, BinNumExpr, CompExpr
 from m2cgen.interpreters.utils import CachedResult, _get_handler_name
 
 
 class BaseInterpreter:
+
+    infix_expressions = [BinNumExpr, CompExpr]
+
     """
     Base class of AST interpreter. Provides single public method .interpret()
     which takes instance of AST expression and recursively applies method
@@ -21,7 +24,7 @@ class BaseInterpreter:
     def _pre_interpret_hook(self, expr, **kwargs):
         return None, kwargs
 
-    def _do_interpret(self, expr, to_reuse=None, **kwargs):
+    def _do_interpret(self, expr, to_reuse=None, left_precedence=None, right_precedence=None, **kwargs):
         # Hook which allows to override kwargs and to return custom result.
         result, kwargs = self._pre_interpret_hook(expr, **kwargs)
 
@@ -34,6 +37,15 @@ class BaseInterpreter:
 
         handler = self._select_handler(expr)
 
+        # Reset precedence on non-infix expressions.
+        if not isinstance(expr, tuple(self.infix_expressions)):
+            left_precedence = None
+            right_precedence = None
+
+        result = handler(
+            expr, left_precedence=left_precedence,
+            right_precedence=right_precedence, **kwargs)
+
         # Note that the reuse flag passed in the arguments has a higher
         # precedence than one specified in the expression. One use case for
         # this behavior is to override the original to_reuse flag for
@@ -41,9 +53,8 @@ class BaseInterpreter:
         # subroutines are not supported by specific interpreter implementation.
         expr_to_reuse = to_reuse if to_reuse is not None else expr.to_reuse
         if not expr_to_reuse:
-            return handler(expr, **kwargs)
+            return result
 
-        result = handler(expr, **kwargs)
         return self._cache_reused_expr(expr, result)
 
     def _cache_reused_expr(self, expr, expr_result):
@@ -107,11 +118,12 @@ class ToCodeInterpreter(BaseToCodeInterpreter):
             op=op,
             right=self._do_interpret(expr.right, **kwargs))
 
-    def interpret_bin_num_expr(self, expr, **kwargs):
+    def interpret_bin_num_expr(self, expr, left_precedence=None, right_precedence=None, **kwargs):
         return self._cg.infix_expression(
-            left=self._do_interpret(expr.left, **kwargs),
+            left=self._do_interpret(expr.left, left_precedence=expr.precedence, **kwargs),
             op=expr.op.value,
-            right=self._do_interpret(expr.right, **kwargs))
+            right=self._do_interpret(expr.right, right_precedence=expr.precedence, **kwargs),
+            wrap=self._wrap_infix_expr(expr, left_precedence, right_precedence))
 
     def interpret_num_val(self, expr, **kwargs):
         return self._cg.num_value(value=expr.value)
@@ -197,6 +209,11 @@ class ToCodeInterpreter(BaseToCodeInterpreter):
         base_result = self._do_interpret(expr.base_expr, **kwargs)
         exp_result = self._do_interpret(expr.exp_expr, **kwargs)
         return self._cg.function_invocation(self.power_function_name, base_result, exp_result)
+
+    def _wrap_infix_expr(self, expr, left_precedence, right_precedence):
+        wrap = left_precedence is not None and left_precedence > expr.precedence
+        wrap |= right_precedence is not None and right_precedence >= expr.precedence
+        return wrap
 
 
 class ImperativeToCodeInterpreter(ToCodeInterpreter):

--- a/m2cgen/interpreters/python/code_generator.py
+++ b/m2cgen/interpreters/python/code_generator.py
@@ -6,7 +6,7 @@ from m2cgen.interpreters.code_generator import CodeTemplate, ImperativeCodeGener
 class PythonCodeGenerator(ImperativeCodeGenerator):
 
     tpl_num_value = CodeTemplate("{value}")
-    tpl_infix_expression = CodeTemplate("({left}) {op} ({right})")
+    tpl_infix_expression = CodeTemplate("{left} {op} {right}")
     tpl_return_statement = CodeTemplate("return {value}")
     tpl_array_index_access = CodeTemplate("{array_name}[{index}]")
     tpl_if_statement = CodeTemplate("if {if_def}:")

--- a/m2cgen/interpreters/ruby/code_generator.py
+++ b/m2cgen/interpreters/ruby/code_generator.py
@@ -7,7 +7,7 @@ class RubyCodeGenerator(ImperativeCodeGenerator):
 
     tpl_var_declaration = CodeTemplate("")
     tpl_num_value = CodeTemplate("{value}")
-    tpl_infix_expression = CodeTemplate("({left}) {op} ({right})")
+    tpl_infix_expression = CodeTemplate("{left} {op} {right}")
     tpl_return_statement = tpl_num_value
     tpl_array_index_access = CodeTemplate("{array_name}[{index}]")
     tpl_if_statement = CodeTemplate("if {if_def}")

--- a/m2cgen/interpreters/ruby/interpreter.py
+++ b/m2cgen/interpreters/ruby/interpreter.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from m2cgen.ast import BinNumOpType
+from m2cgen.ast import BinNumOpType, PowExpr
 from m2cgen.interpreters.interpreter import ImperativeToCodeInterpreter
 from m2cgen.interpreters.mixins import LinearAlgebraMixin
 from m2cgen.interpreters.ruby.code_generator import RubyCodeGenerator
@@ -9,6 +9,8 @@ from m2cgen.interpreters.utils import get_file_content
 
 class RubyInterpreter(ImperativeToCodeInterpreter,
                       LinearAlgebraMixin):
+
+    infix_expressions = [*ImperativeToCodeInterpreter.infix_expressions, PowExpr]
 
     supported_bin_vector_ops = {
         BinNumOpType.ADD: "add_vectors",
@@ -84,11 +86,15 @@ class RubyInterpreter(ImperativeToCodeInterpreter,
             obj=self._do_interpret(expr.expr, **kwargs),
             args=[])
 
-    def interpret_pow_expr(self, expr, **kwargs):
-        base_result = self._do_interpret(expr.base_expr, **kwargs)
-        exp_result = self._do_interpret(expr.exp_expr, **kwargs)
+    def interpret_pow_expr(self, expr, left_precedence=None,
+                           right_precedence=None, **kwargs):
+        base_result = self._do_interpret(
+            expr.base_expr, left_precedence=expr.precedence, **kwargs)
+        exp_result = self._do_interpret(
+            expr.exp_expr, right_precedence=expr.precedence, **kwargs)
         return self._cg.infix_expression(
-            left=base_result, right=exp_result, op="**")
+            left=base_result, right=exp_result, op="**",
+            wrap=self._wrap_infix_expr(expr, left_precedence, right_precedence))
 
     def interpret_log1p_expr(self, expr, **kwargs):
         self.with_log1p_expr = True

--- a/m2cgen/interpreters/visual_basic/code_generator.py
+++ b/m2cgen/interpreters/visual_basic/code_generator.py
@@ -6,7 +6,7 @@ from m2cgen.interpreters.code_generator import CodeTemplate, ImperativeCodeGener
 
 class VisualBasicCodeGenerator(ImperativeCodeGenerator):
     tpl_num_value = CodeTemplate("{value}")
-    tpl_infix_expression = CodeTemplate("({left}) {op} ({right})")
+    tpl_infix_expression = CodeTemplate("{left} {op} {right}")
     tpl_var_declaration = CodeTemplate("Dim {var_name}{type_modifier} As {var_type}")
     tpl_return_statement = CodeTemplate("{func_name} = {value}")
     tpl_if_statement = CodeTemplate("If {if_def} Then")

--- a/m2cgen/interpreters/visual_basic/interpreter.py
+++ b/m2cgen/interpreters/visual_basic/interpreter.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from m2cgen.ast import BinNumOpType
+from m2cgen.ast import BinNumOpType, PowExpr
 from m2cgen.interpreters.interpreter import ImperativeToCodeInterpreter
 from m2cgen.interpreters.mixins import LinearAlgebraMixin
 from m2cgen.interpreters.utils import get_file_content
@@ -9,6 +9,9 @@ from m2cgen.interpreters.visual_basic.code_generator import VisualBasicCodeGener
 
 class VisualBasicInterpreter(ImperativeToCodeInterpreter,
                              LinearAlgebraMixin):
+
+    infix_expressions = [*ImperativeToCodeInterpreter.infix_expressions, PowExpr]
+
     supported_bin_vector_ops = {
         BinNumOpType.ADD: "AddVectors",
     }
@@ -88,11 +91,15 @@ class VisualBasicInterpreter(ImperativeToCodeInterpreter,
 
         return self._cg.finalize_and_get_generated_code()
 
-    def interpret_pow_expr(self, expr, **kwargs):
-        base_result = self._do_interpret(expr.base_expr, **kwargs)
-        exp_result = self._do_interpret(expr.exp_expr, **kwargs)
+    def interpret_pow_expr(self, expr, left_precedence=None,
+                           right_precedence=None, **kwargs):
+        base_result = self._do_interpret(
+            expr.base_expr, left_precedence=expr.precedence, **kwargs)
+        exp_result = self._do_interpret(
+            expr.exp_expr, right_precedence=expr.precedence, **kwargs)
         return self._cg.infix_expression(
-            left=base_result, right=exp_result, op="^")
+            left=base_result, right=exp_result, op="^",
+            wrap=self._wrap_infix_expr(expr, left_precedence, right_precedence))
 
     def interpret_log1p_expr(self, expr, **kwargs):
         self.with_log1p_expr = True

--- a/tests/interpreters/test_c.py
+++ b/tests/interpreters/test_c.py
@@ -15,7 +15,7 @@ def test_if_expr():
     expected_code = """
 double score(double * input) {
     double var0;
-    if ((1.0) == (input[0])) {
+    if (1.0 == input[0]) {
         var0 = 2.0;
     } else {
         var0 = 3.0;
@@ -37,7 +37,7 @@ def test_bin_num_expr():
 
     expected_code = """
 double score(double * input) {
-    return ((input[0]) / (-2.0)) * (2.0);
+    return input[0] / -2.0 * 2.0;
 }
 """
 
@@ -63,12 +63,12 @@ def test_dependable_condition():
 double score(double * input) {
     double var0;
     double var1;
-    if ((1.0) == (1.0)) {
+    if (1.0 == 1.0) {
         var1 = 1.0;
     } else {
         var1 = 2.0;
     }
-    if (((var1) + (2.0)) >= ((1.0) / (2.0))) {
+    if (var1 + 2.0 >= 1.0 / 2.0) {
         var0 = 1.0;
     } else {
         var0 = input[0];
@@ -99,19 +99,19 @@ def test_nested_condition():
 double score(double * input) {
     double var0;
     double var1;
-    if ((1.0) == (1.0)) {
+    if (1.0 == 1.0) {
         var1 = 1.0;
     } else {
         var1 = 2.0;
     }
-    if ((1.0) == ((var1) + (2.0))) {
+    if (1.0 == var1 + 2.0) {
         double var2;
-        if ((1.0) == (1.0)) {
+        if (1.0 == 1.0) {
             var2 = 1.0;
         } else {
             var2 = 2.0;
         }
-        if ((1.0) == ((var2) + (2.0))) {
+        if (1.0 == var2 + 2.0) {
             var0 = input[2];
         } else {
             var0 = 2.0;
@@ -154,7 +154,7 @@ def test_multi_output():
 #include <string.h>
 void score(double * input, double * output) {
     double var0[2];
-    if ((1.0) != (1.0)) {
+    if (1.0 != 1.0) {
         memcpy(var0, (double[]){1.0, 2.0}, 2 * sizeof(double));
     } else {
         memcpy(var0, (double[]){3.0, 4.0}, 2 * sizeof(double));
@@ -393,7 +393,7 @@ def test_reused_expr():
 double score(double * input) {
     double var0;
     var0 = exp(1.0);
-    return (var0) / (var0);
+    return var0 / var0;
 }
 """
 

--- a/tests/interpreters/test_c_sharp.py
+++ b/tests/interpreters/test_c_sharp.py
@@ -17,7 +17,7 @@ namespace ML {
     public static class Model {
         public static double Score(double[] input) {
             double var0;
-            if ((1.0) == (input[0])) {
+            if (1.0 == input[0]) {
                 var0 = 2.0;
             } else {
                 var0 = 3.0;
@@ -43,7 +43,7 @@ def test_bin_num_expr():
 namespace ML {
     public static class Model {
         public static double Score(double[] input) {
-            return ((input[0]) / (-2.0)) * (2.0);
+            return input[0] / -2.0 * 2.0;
         }
     }
 }
@@ -73,12 +73,12 @@ namespace ML {
         public static double Score(double[] input) {
             double var0;
             double var1;
-            if ((1.0) == (1.0)) {
+            if (1.0 == 1.0) {
                 var1 = 1.0;
             } else {
                 var1 = 2.0;
             }
-            if (((var1) + (2.0)) >= ((1.0) / (2.0))) {
+            if (var1 + 2.0 >= 1.0 / 2.0) {
                 var0 = 1.0;
             } else {
                 var0 = input[0];
@@ -113,19 +113,19 @@ namespace ML {
         public static double Score(double[] input) {
             double var0;
             double var1;
-            if ((1.0) == (1.0)) {
+            if (1.0 == 1.0) {
                 var1 = 1.0;
             } else {
                 var1 = 2.0;
             }
-            if ((1.0) == ((var1) + (2.0))) {
+            if (1.0 == var1 + 2.0) {
                 double var2;
-                if ((1.0) == (1.0)) {
+                if (1.0 == 1.0) {
                     var2 = 1.0;
                 } else {
                     var2 = 2.0;
                 }
-                if ((1.0) == ((var2) + (2.0))) {
+                if (1.0 == var2 + 2.0) {
                     var0 = input[2];
                 } else {
                     var0 = 2.0;
@@ -208,7 +208,7 @@ namespace ML {
     public static class Model {
         public static double[] Score(double[] input) {
             double[] var0;
-            if ((1.0) != (1.0)) {
+            if (1.0 != 1.0) {
                 var0 = new double[2] {1.0, 2.0};
             } else {
                 var0 = new double[2] {3.0, 4.0};
@@ -557,7 +557,7 @@ namespace ML {
         public static double Score(double[] input) {
             double var0;
             var0 = Exp(1.0);
-            return (var0) / (var0);
+            return var0 / var0;
         }
     }
 }

--- a/tests/interpreters/test_dart.py
+++ b/tests/interpreters/test_dart.py
@@ -15,7 +15,7 @@ def test_if_expr():
     expected_code = """
 double score(List<double> input) {
     double var0;
-    if ((1.0) == (input[0])) {
+    if (1.0 == input[0]) {
         var0 = 2.0;
     } else {
         var0 = 3.0;
@@ -37,7 +37,7 @@ def test_bin_num_expr():
 
     expected_code = """
 double score(List<double> input) {
-    return ((input[0]) / (-2.0)) * (2.0);
+    return input[0] / -2.0 * 2.0;
 }
 """
 
@@ -63,12 +63,12 @@ def test_dependable_condition():
 double score(List<double> input) {
     double var0;
     double var1;
-    if ((1.0) == (1.0)) {
+    if (1.0 == 1.0) {
         var1 = 1.0;
     } else {
         var1 = 2.0;
     }
-    if (((var1) + (2.0)) >= ((1.0) / (2.0))) {
+    if (var1 + 2.0 >= 1.0 / 2.0) {
         var0 = 1.0;
     } else {
         var0 = input[0];
@@ -99,19 +99,19 @@ def test_nested_condition():
 double score(List<double> input) {
     double var0;
     double var1;
-    if ((1.0) == (1.0)) {
+    if (1.0 == 1.0) {
         var1 = 1.0;
     } else {
         var1 = 2.0;
     }
-    if ((1.0) == ((var1) + (2.0))) {
+    if (1.0 == var1 + 2.0) {
         double var2;
-        if ((1.0) == (1.0)) {
+        if (1.0 == 1.0) {
             var2 = 1.0;
         } else {
             var2 = 2.0;
         }
-        if ((1.0) == ((var2) + (2.0))) {
+        if (1.0 == var2 + 2.0) {
             var0 = input[2];
         } else {
             var0 = 2.0;
@@ -152,7 +152,7 @@ def test_multi_output():
     expected_code = """
 List<double> score(List<double> input) {
     List<double> var0;
-    if ((1.0) != (1.0)) {
+    if (1.0 != 1.0) {
         var0 = [1.0, 2.0];
     } else {
         var0 = [3.0, 4.0];
@@ -237,8 +237,8 @@ def test_depth_threshold_with_bin_expr():
     expected_code = """
 double score(List<double> input) {
     double var0;
-    var0 = (1.0) + ((1.0) + (1.0));
-    return (1.0) + ((1.0) + (var0));
+    var0 = 1.0 + (1.0 + 1.0);
+    return 1.0 + (1.0 + var0);
 }
 """
 
@@ -254,10 +254,10 @@ def test_depth_threshold_with_reused_bin_expr():
     expected_code = """
 double score(List<double> input) {
     double var0;
-    var0 = (1.0) + (1.0);
+    var0 = 1.0 + 1.0;
     double var1;
     var1 = var0;
-    return ((1.0) + (var1)) + ((1.0) + (var0));
+    return 1.0 + var1 + (1.0 + var0);
 }
 """
 
@@ -277,16 +277,16 @@ def test_depth_threshold_without_bin_expr():
     expected_code = """
 double score(List<double> input) {
     double var0;
-    if ((1.0) == (1.0)) {
+    if (1.0 == 1.0) {
         var0 = 1.0;
     } else {
-        if ((1.0) == (1.0)) {
+        if (1.0 == 1.0) {
             var0 = 1.0;
         } else {
-            if ((1.0) == (1.0)) {
+            if (1.0 == 1.0) {
                 var0 = 1.0;
             } else {
-                if ((1.0) == (1.0)) {
+                if (1.0 == 1.0) {
                     var0 = 1.0;
                 } else {
                     var0 = 1.0;
@@ -317,16 +317,16 @@ def test_deep_mixed_exprs_not_reaching_threshold():
     expected_code = """
 double score(List<double> input) {
     double var0;
-    if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+    if (1.0 + (1.0 + 1.0) == 1.0) {
         var0 = 1.0;
     } else {
-        if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+        if (1.0 + (1.0 + 1.0) == 1.0) {
             var0 = 1.0;
         } else {
-            if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+            if (1.0 + (1.0 + 1.0) == 1.0) {
                 var0 = 1.0;
             } else {
-                if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+                if (1.0 + (1.0 + 1.0) == 1.0) {
                     var0 = 1.0;
                 } else {
                     var0 = 1.0;
@@ -358,23 +358,23 @@ def test_deep_mixed_exprs_exceeding_threshold():
 double score(List<double> input) {
     double var0;
     double var1;
-    var1 = (3.0) + ((3.0) + (1.0));
-    if (((3.0) + ((3.0) + (var1))) == (1.0)) {
+    var1 = 3.0 + (3.0 + 1.0);
+    if (3.0 + (3.0 + var1) == 1.0) {
         var0 = 1.0;
     } else {
         double var2;
-        var2 = (2.0) + ((2.0) + (1.0));
-        if (((2.0) + ((2.0) + (var2))) == (1.0)) {
+        var2 = 2.0 + (2.0 + 1.0);
+        if (2.0 + (2.0 + var2) == 1.0) {
             var0 = 1.0;
         } else {
             double var3;
-            var3 = (1.0) + ((1.0) + (1.0));
-            if (((1.0) + ((1.0) + (var3))) == (1.0)) {
+            var3 = 1.0 + (1.0 + 1.0);
+            if (1.0 + (1.0 + var3) == 1.0) {
                 var0 = 1.0;
             } else {
                 double var4;
-                var4 = (0.0) + ((0.0) + (1.0));
-                if (((0.0) + ((0.0) + (var4))) == (1.0)) {
+                var4 = 0.0 + (0.0 + 1.0);
+                if (0.0 + (0.0 + var4) == 1.0) {
                     var0 = 1.0;
                 } else {
                     var0 = 1.0;
@@ -638,7 +638,7 @@ import 'dart:math';
 double score(List<double> input) {
     double var0;
     var0 = exp(1.0);
-    return (var0) / (var0);
+    return var0 / var0;
 }
 """
 

--- a/tests/interpreters/test_elixir.py
+++ b/tests/interpreters/test_elixir.py
@@ -23,7 +23,7 @@ defmodule Model do
     def score(input) do
         input = list_to_binary(input)
         func0 = fn ->
-            cond do (1.0) == (read(input,0)) ->
+            cond do 1.0 == read(input,0) ->
                 2.0
             true ->
                 3.0
@@ -57,7 +57,7 @@ defmodule Model do
     end
     def score(input) do
         input = list_to_binary(input)
-        ((read(input,0)) / (-2.0)) * (2.0)
+        read(input,0) / -2.0 * 2.0
     end
 end
 """
@@ -93,14 +93,14 @@ defmodule Model do
     def score(input) do
         input = list_to_binary(input)
         func0 = fn ->
-            cond do (1.0) == (1.0) ->
+            cond do 1.0 == 1.0 ->
                 1.0
             true ->
                 2.0
             end
         end
         func1 = fn ->
-            cond do ((func0.()) + (2.0)) >= ((1.0) / (2.0)) ->
+            cond do func0.() + 2.0 >= 1.0 / 2.0 ->
                 1.0
             true ->
                 read(input,0)
@@ -142,15 +142,15 @@ defmodule Model do
     def score(input) do
         input = list_to_binary(input)
         func0 = fn ->
-            cond do (1.0) == (1.0) ->
+            cond do 1.0 == 1.0 ->
                 1.0
             true ->
                 2.0
             end
         end
         func1 = fn ->
-            cond do (1.0) == ((func0.()) + (2.0)) ->
-                cond do (1.0) == ((func0.()) + (2.0)) ->
+            cond do 1.0 == func0.() + 2.0 ->
+                cond do 1.0 == func0.() + 2.0 ->
                     read(input,2)
                 true ->
                     2.0
@@ -214,7 +214,7 @@ defmodule Model do
     def score(input) do
         input = list_to_binary(input)
         func0 = fn ->
-            cond do (1.0) != (1.0) ->
+            cond do 1.0 != 1.0 ->
                 [1.0, 2.0]
             true ->
                 [3.0, 4.0]
@@ -319,9 +319,9 @@ defmodule Model do
     def score(input) do
         input = list_to_binary(input)
         func0 = fn ->
-            (1.0) + ((1.0) + (1.0))
+            1.0 + (1.0 + 1.0)
         end
-        (1.0) + ((1.0) + (func0.()))
+        1.0 + (1.0 + func0.())
     end
 end
 """
@@ -352,16 +352,16 @@ defmodule Model do
     def score(input) do
         input = list_to_binary(input)
         func0 = fn ->
-            cond do (1.0) == (1.0) ->
+            cond do 1.0 == 1.0 ->
                 1.0
             true ->
-                cond do (1.0) == (1.0) ->
+                cond do 1.0 == 1.0 ->
                     1.0
                 true ->
-                    cond do (1.0) == (1.0) ->
+                    cond do 1.0 == 1.0 ->
                         1.0
                     true ->
-                        cond do (1.0) == (1.0) ->
+                        cond do 1.0 == 1.0 ->
                             1.0
                         true ->
                             1.0
@@ -404,16 +404,16 @@ defmodule Model do
     def score(input) do
         input = list_to_binary(input)
         func0 = fn ->
-            cond do ((1.0) + ((1.0) + (1.0))) == (1.0) ->
+            cond do 1.0 + (1.0 + 1.0) == 1.0 ->
                 1.0
             true ->
-                cond do ((1.0) + ((1.0) + (1.0))) == (1.0) ->
+                cond do 1.0 + (1.0 + 1.0) == 1.0 ->
                     1.0
                 true ->
-                    cond do ((1.0) + ((1.0) + (1.0))) == (1.0) ->
+                    cond do 1.0 + (1.0 + 1.0) == 1.0 ->
                         1.0
                     true ->
-                        cond do ((1.0) + ((1.0) + (1.0))) == (1.0) ->
+                        cond do 1.0 + (1.0 + 1.0) == 1.0 ->
                             1.0
                         true ->
                             1.0
@@ -456,28 +456,28 @@ defmodule Model do
     def score(input) do
         input = list_to_binary(input)
         func0 = fn ->
-            (3.0) + ((3.0) + (1.0))
+            3.0 + (3.0 + 1.0)
         end
         func1 = fn ->
-            (2.0) + ((2.0) + (1.0))
+            2.0 + (2.0 + 1.0)
         end
         func2 = fn ->
-            (1.0) + ((1.0) + (1.0))
+            1.0 + (1.0 + 1.0)
         end
         func3 = fn ->
-            (0.0) + ((0.0) + (1.0))
+            0.0 + (0.0 + 1.0)
         end
         func4 = fn ->
-            cond do ((3.0) + ((3.0) + (func0.()))) == (3.0) ->
+            cond do 3.0 + (3.0 + func0.()) == 3.0 ->
                 1.0
             true ->
-                cond do ((2.0) + ((2.0) + (func1.()))) == (3.0) ->
+                cond do 2.0 + (2.0 + func1.()) == 3.0 ->
                     1.0
                 true ->
-                    cond do ((1.0) + ((1.0) + (func2.()))) == (3.0) ->
+                    cond do 1.0 + (1.0 + func2.()) == 3.0 ->
                         1.0
                     true ->
-                        cond do ((0.0) + ((0.0) + (func3.()))) == (3.0) ->
+                        cond do 0.0 + (0.0 + func3.()) == 3.0 ->
                             1.0
                         true ->
                             1.0
@@ -810,7 +810,7 @@ defmodule Model do
         func0 = fn ->
             :math.exp(1.0)
         end
-        (func0.()) / (func0.())
+        func0.() / func0.()
     end
 end
 """

--- a/tests/interpreters/test_f_sharp.py
+++ b/tests/interpreters/test_f_sharp.py
@@ -15,7 +15,7 @@ def test_if_expr():
     expected_code = """
 let score (input : double list) =
     let func0 =
-        if (1.0) = (input.[0]) then
+        if 1.0 = input.[0] then
             2.0
         else
             3.0
@@ -35,7 +35,7 @@ def test_bin_num_expr():
 
     expected_code = """
 let score (input : double list) =
-    ((input.[0]) / (-2.0)) * (2.0)
+    input.[0] / -2.0 * 2.0
 """
 
     interpreter = FSharpInterpreter()
@@ -59,12 +59,12 @@ def test_dependable_condition():
     expected_code = """
 let score (input : double list) =
     let func0 =
-        if (1.0) = (1.0) then
+        if 1.0 = 1.0 then
             1.0
         else
             2.0
     let func1 =
-        if ((func0) + (2.0)) >= ((1.0) / (2.0)) then
+        if func0 + 2.0 >= 1.0 / 2.0 then
             1.0
         else
             input.[0]
@@ -92,13 +92,13 @@ def test_nested_condition():
     expected_code = """
 let score (input : double list) =
     let func0 =
-        if (1.0) = (1.0) then
+        if 1.0 = 1.0 then
             1.0
         else
             2.0
     let func1 =
-        if (1.0) = ((func0) + (2.0)) then
-            if (1.0) = ((func0) + (2.0)) then
+        if 1.0 = func0 + 2.0 then
+            if 1.0 = func0 + 2.0 then
                 input.[2]
             else
                 2.0
@@ -135,7 +135,7 @@ def test_multi_output():
     expected_code = """
 let score (input : double list) =
     let func0 =
-        if (1.0) <> (1.0) then
+        if 1.0 <> 1.0 then
             [1.0; 2.0]
         else
             [3.0; 4.0]
@@ -192,8 +192,8 @@ def test_depth_threshold_with_bin_expr():
     expected_code = """
 let score (input : double list) =
     let func0 =
-        (1.0) + ((1.0) + (1.0))
-    (1.0) + ((1.0) + (func0))
+        1.0 + (1.0 + 1.0)
+    1.0 + (1.0 + func0)
 """
 
     interpreter = CustomFSharpInterpreter()
@@ -208,8 +208,8 @@ def test_depth_threshold_with_reused_bin_expr():
     expected_code = """
 let score (input : double list) =
     let func0 =
-        (1.0) + (1.0)
-    ((1.0) + (func0)) + ((1.0) + (func0))
+        1.0 + 1.0
+    1.0 + func0 + (1.0 + func0)
 """
 
     interpreter = CustomFSharpInterpreter()
@@ -228,16 +228,16 @@ def test_depth_threshold_without_bin_expr():
     expected_code = """
 let score (input : double list) =
     let func0 =
-        if (1.0) = (1.0) then
+        if 1.0 = 1.0 then
             1.0
         else
-            if (1.0) = (1.0) then
+            if 1.0 = 1.0 then
                 1.0
             else
-                if (1.0) = (1.0) then
+                if 1.0 = 1.0 then
                     1.0
                 else
-                    if (1.0) = (1.0) then
+                    if 1.0 = 1.0 then
                         1.0
                     else
                         1.0
@@ -263,16 +263,16 @@ def test_deep_mixed_exprs_not_reaching_threshold():
     expected_code = """
 let score (input : double list) =
     let func0 =
-        if ((1.0) + ((1.0) + (1.0))) = (1.0) then
+        if 1.0 + (1.0 + 1.0) = 1.0 then
             1.0
         else
-            if ((1.0) + ((1.0) + (1.0))) = (1.0) then
+            if 1.0 + (1.0 + 1.0) = 1.0 then
                 1.0
             else
-                if ((1.0) + ((1.0) + (1.0))) = (1.0) then
+                if 1.0 + (1.0 + 1.0) = 1.0 then
                     1.0
                 else
-                    if ((1.0) + ((1.0) + (1.0))) = (1.0) then
+                    if 1.0 + (1.0 + 1.0) = 1.0 then
                         1.0
                     else
                         1.0
@@ -298,24 +298,24 @@ def test_deep_mixed_exprs_exceeding_threshold():
     expected_code = """
 let score (input : double list) =
     let func0 =
-        (3.0) + ((3.0) + (1.0))
+        3.0 + (3.0 + 1.0)
     let func1 =
-        (2.0) + ((2.0) + (1.0))
+        2.0 + (2.0 + 1.0)
     let func2 =
-        (1.0) + ((1.0) + (1.0))
+        1.0 + (1.0 + 1.0)
     let func3 =
-        (0.0) + ((0.0) + (1.0))
+        0.0 + (0.0 + 1.0)
     let func4 =
-        if ((3.0) + ((3.0) + (func0))) = (1.0) then
+        if 3.0 + (3.0 + func0) = 1.0 then
             1.0
         else
-            if ((2.0) + ((2.0) + (func1))) = (1.0) then
+            if 2.0 + (2.0 + func1) = 1.0 then
                 1.0
             else
-                if ((1.0) + ((1.0) + (func2))) = (1.0) then
+                if 1.0 + (1.0 + func2) = 1.0 then
                     1.0
                 else
-                    if ((0.0) + ((0.0) + (func3))) = (1.0) then
+                    if 0.0 + (0.0 + func3) = 1.0 then
                         1.0
                     else
                         1.0
@@ -355,7 +355,7 @@ def test_pow_expr():
 
     expected_code = """
 let score (input : double list) =
-    (2.0) ** (3.0)
+    2.0 ** 3.0
 """
 
     interpreter = FSharpInterpreter()
@@ -504,7 +504,7 @@ def test_reused_expr():
 let score (input : double list) =
     let func0 =
         exp (1.0)
-    (func0) / (func0)
+    func0 / func0
 """
 
     interpreter = FSharpInterpreter()

--- a/tests/interpreters/test_go.py
+++ b/tests/interpreters/test_go.py
@@ -15,7 +15,7 @@ def test_if_expr():
     expected_code = """
 func score(input []float64) float64 {
     var var0 float64
-    if (1.0) == (input[0]) {
+    if 1.0 == input[0] {
         var0 = 2.0
     } else {
         var0 = 3.0
@@ -37,7 +37,7 @@ def test_bin_num_expr():
 
     expected_code = """
 func score(input []float64) float64 {
-    return ((input[0]) / (-2.0)) * (2.0)
+    return input[0] / -2.0 * 2.0
 }
 """
 
@@ -63,12 +63,12 @@ def test_dependable_condition():
 func score(input []float64) float64 {
     var var0 float64
     var var1 float64
-    if (1.0) == (1.0) {
+    if 1.0 == 1.0 {
         var1 = 1.0
     } else {
         var1 = 2.0
     }
-    if ((var1) + (2.0)) >= ((1.0) / (2.0)) {
+    if var1 + 2.0 >= 1.0 / 2.0 {
         var0 = 1.0
     } else {
         var0 = input[0]
@@ -99,19 +99,19 @@ def test_nested_condition():
 func score(input []float64) float64 {
     var var0 float64
     var var1 float64
-    if (1.0) == (1.0) {
+    if 1.0 == 1.0 {
         var1 = 1.0
     } else {
         var1 = 2.0
     }
-    if (1.0) == ((var1) + (2.0)) {
+    if 1.0 == var1 + 2.0 {
         var var2 float64
-        if (1.0) == (1.0) {
+        if 1.0 == 1.0 {
             var2 = 1.0
         } else {
             var2 = 2.0
         }
-        if (1.0) == ((var2) + (2.0)) {
+        if 1.0 == var2 + 2.0 {
             var0 = input[2]
         } else {
             var0 = 2.0
@@ -152,7 +152,7 @@ def test_multi_output():
     expected_code = """
 func score(input []float64) []float64 {
     var var0 []float64
-    if (1.0) != (1.0) {
+    if 1.0 != 1.0 {
         var0 = []float64{1.0, 2.0}
     } else {
         var0 = []float64{3.0, 4.0}
@@ -400,7 +400,7 @@ import "math"
 func score(input []float64) float64 {
     var var0 float64
     var0 = math.Exp(1.0)
-    return (var0) / (var0)
+    return var0 / var0
 }
 """
 

--- a/tests/interpreters/test_haskell.py
+++ b/tests/interpreters/test_haskell.py
@@ -19,7 +19,7 @@ score input =
     func0
     where
         func0 =
-            if (1.0) == ((input) !! (0)) then
+            if 1.0 == input !! 0 then
                 2.0
             else
                 3.0
@@ -40,7 +40,7 @@ def test_bin_num_expr():
 module Model where
 score :: [Double] -> Double
 score input =
-    (((input) !! (0)) / (-2.0)) * (2.0)
+    input !! 0 / -2.0 * 2.0
 """
 
     interpreter = HaskellInterpreter()
@@ -68,15 +68,15 @@ score input =
     func1
     where
         func0 =
-            if (1.0) == (1.0) then
+            if 1.0 == 1.0 then
                 1.0
             else
                 2.0
         func1 =
-            if ((func0) + (2.0)) >= ((1.0) / (2.0)) then
+            if func0 + 2.0 >= 1.0 / 2.0 then
                 1.0
             else
-                (input) !! (0)
+                input !! 0
 """
 
     interpreter = HaskellInterpreter()
@@ -104,14 +104,14 @@ score input =
     func1
     where
         func0 =
-            if (1.0) == (1.0) then
+            if 1.0 == 1.0 then
                 1.0
             else
                 2.0
         func1 =
-            if (1.0) == ((func0) + (2.0)) then
-                if (1.0) == ((func0) + (2.0)) then
-                    (input) !! (2)
+            if 1.0 == func0 + 2.0 then
+                if 1.0 == func0 + 2.0 then
+                    input !! 2
                 else
                     2.0
             else
@@ -152,7 +152,7 @@ score input =
     func0
     where
         func0 =
-            if (1.0) /= (1.0) then
+            if 1.0 /= 1.0 then
                 [1.0, 2.0]
             else
                 [3.0, 4.0]
@@ -239,7 +239,7 @@ def test_pow_expr():
 module Model where
 score :: [Double] -> Double
 score input =
-    (2.0) ** (3.0)
+    2.0 ** 3.0
 """
 
     interpreter = HaskellInterpreter()
@@ -406,7 +406,7 @@ def test_reused_expr():
 module Model where
 score :: [Double] -> Double
 score input =
-    (func0) / (func0)
+    func0 / func0
     where
         func0 =
             exp (1.0)

--- a/tests/interpreters/test_java.py
+++ b/tests/interpreters/test_java.py
@@ -16,7 +16,7 @@ def test_if_expr():
 public class Model {
     public static double score(double[] input) {
         double var0;
-        if ((1.0) == (input[0])) {
+        if (1.0 == input[0]) {
             var0 = 2.0;
         } else {
             var0 = 3.0;
@@ -40,7 +40,7 @@ def test_bin_num_expr():
     expected_code = """
 public class Model {
     public static double score(double[] input) {
-        return ((input[0]) / (-2.0)) * (2.0);
+        return input[0] / -2.0 * 2.0;
     }
 }
 """
@@ -68,12 +68,12 @@ public class Model {
     public static double score(double[] input) {
         double var0;
         double var1;
-        if ((1.0) == (1.0)) {
+        if (1.0 == 1.0) {
             var1 = 1.0;
         } else {
             var1 = 2.0;
         }
-        if (((var1) + (2.0)) >= ((1.0) / (2.0))) {
+        if (var1 + 2.0 >= 1.0 / 2.0) {
             var0 = 1.0;
         } else {
             var0 = input[0];
@@ -106,19 +106,19 @@ public class Model {
     public static double score(double[] input) {
         double var0;
         double var1;
-        if ((1.0) == (1.0)) {
+        if (1.0 == 1.0) {
             var1 = 1.0;
         } else {
             var1 = 2.0;
         }
-        if ((1.0) == ((var1) + (2.0))) {
+        if (1.0 == var1 + 2.0) {
             double var2;
-            if ((1.0) == (1.0)) {
+            if (1.0 == 1.0) {
                 var2 = 1.0;
             } else {
                 var2 = 2.0;
             }
-            if ((1.0) == ((var2) + (2.0))) {
+            if (1.0 == var2 + 2.0) {
                 var0 = input[2];
             } else {
                 var0 = 2.0;
@@ -160,7 +160,7 @@ def test_ignores_subroutine_expr():
     expected_code = """
 public class Model {
     public static double score(double[] input) {
-        return (input[0]) * ((1.0) + (2.0));
+        return input[0] * (1.0 + 2.0);
     }
 }
 """
@@ -197,7 +197,7 @@ def test_multi_output():
 public class Model {
     public static double[] score(double[] input) {
         double[] var0;
-        if ((1.0) != (1.0)) {
+        if (1.0 != 1.0) {
             var0 = new double[] {1.0, 2.0};
         } else {
             var0 = new double[] {3.0, 4.0};
@@ -288,10 +288,10 @@ def test_depth_threshold_with_bin_expr():
     expected_code = """
 public class Model {
     public static double score(double[] input) {
-        return (1.0) + ((1.0) + (subroutine0(input)));
+        return 1.0 + (1.0 + subroutine0(input));
     }
     public static double subroutine0(double[] input) {
-        return (1.0) + ((1.0) + (1.0));
+        return 1.0 + (1.0 + 1.0);
     }
 }
 """
@@ -309,27 +309,27 @@ def test_depth_threshold_with_reused_bin_expr():
     expected_code = """
 public class Model {
     public static double score(double[] input) {
-        return ((subroutine0(input)) + (subroutine1(input))) + ((subroutine2(input)) + (subroutine3(input)));
+        return subroutine0(input) + subroutine1(input) + (subroutine2(input) + subroutine3(input));
     }
     public static double subroutine0(double[] input) {
         double var0;
-        var0 = (1.0) + (1.0);
-        return (1.0) + (var0);
+        var0 = (1.0 + 1.0);
+        return 1.0 + var0;
     }
     public static double subroutine1(double[] input) {
         double var0;
-        var0 = (1.0) + (1.0);
-        return (1.0) + (var0);
+        var0 = (1.0 + 1.0);
+        return 1.0 + var0;
     }
     public static double subroutine2(double[] input) {
         double var0;
-        var0 = (1.0) + (1.0);
-        return (1.0) + (var0);
+        var0 = (1.0 + 1.0);
+        return 1.0 + var0;
     }
     public static double subroutine3(double[] input) {
         double var0;
-        var0 = (1.0) + (1.0);
-        return (1.0) + (var0);
+        var0 = (1.0 + 1.0);
+        return 1.0 + var0;
     }
 }
 """
@@ -351,16 +351,16 @@ def test_depth_threshold_without_bin_expr():
 public class Model {
     public static double score(double[] input) {
         double var0;
-        if ((1.0) == (1.0)) {
+        if (1.0 == 1.0) {
             var0 = 1.0;
         } else {
-            if ((1.0) == (1.0)) {
+            if (1.0 == 1.0) {
                 var0 = 1.0;
             } else {
-                if ((1.0) == (1.0)) {
+                if (1.0 == 1.0) {
                     var0 = 1.0;
                 } else {
-                    if ((1.0) == (1.0)) {
+                    if (1.0 == 1.0) {
                         var0 = 1.0;
                     } else {
                         var0 = 1.0;
@@ -394,16 +394,16 @@ def test_deep_mixed_exprs_not_reaching_threshold():
 public class Model {
     public static double score(double[] input) {
         double var0;
-        if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+        if (1.0 + (1.0 + 1.0) == 1.0) {
             var0 = 1.0;
         } else {
-            if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+            if (1.0 + (1.0 + 1.0) == 1.0) {
                 var0 = 1.0;
             } else {
-                if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+                if (1.0 + (1.0 + 1.0) == 1.0) {
                     var0 = 1.0;
                 } else {
-                    if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+                    if (1.0 + (1.0 + 1.0) == 1.0) {
                         var0 = 1.0;
                     } else {
                         var0 = 1.0;
@@ -436,16 +436,16 @@ def test_deep_mixed_exprs_exceeding_threshold():
 public class Model {
     public static double score(double[] input) {
         double var0;
-        if (((3.0) + ((3.0) + (subroutine0(input)))) == (1.0)) {
+        if (3.0 + (3.0 + subroutine0(input)) == 1.0) {
             var0 = 1.0;
         } else {
-            if (((2.0) + ((2.0) + (subroutine1(input)))) == (1.0)) {
+            if (2.0 + (2.0 + subroutine1(input)) == 1.0) {
                 var0 = 1.0;
             } else {
-                if (((1.0) + ((1.0) + (subroutine2(input)))) == (1.0)) {
+                if (1.0 + (1.0 + subroutine2(input)) == 1.0) {
                     var0 = 1.0;
                 } else {
-                    if (((0.0) + ((0.0) + (subroutine3(input)))) == (1.0)) {
+                    if (0.0 + (0.0 + subroutine3(input)) == 1.0) {
                         var0 = 1.0;
                     } else {
                         var0 = 1.0;
@@ -456,16 +456,16 @@ public class Model {
         return var0;
     }
     public static double subroutine0(double[] input) {
-        return (3.0) + ((3.0) + (1.0));
+        return 3.0 + (3.0 + 1.0);
     }
     public static double subroutine1(double[] input) {
-        return (2.0) + ((2.0) + (1.0));
+        return 2.0 + (2.0 + 1.0);
     }
     public static double subroutine2(double[] input) {
-        return (1.0) + ((1.0) + (1.0));
+        return 1.0 + (1.0 + 1.0);
     }
     public static double subroutine3(double[] input) {
-        return (0.0) + ((0.0) + (1.0));
+        return 0.0 + (0.0 + 1.0);
     }
 }
 """
@@ -657,7 +657,7 @@ public class Model {
     public static double score(double[] input) {
         double var0;
         var0 = Math.exp(1.0);
-        return (var0) / (var0);
+        return var0 / var0;
     }
 }
 """

--- a/tests/interpreters/test_javascript.py
+++ b/tests/interpreters/test_javascript.py
@@ -15,7 +15,7 @@ def test_if_expr():
     expected_code = """
 function score(input) {
     var var0;
-    if ((1.0) === (input[0])) {
+    if (1.0 === input[0]) {
         var0 = 2.0;
     } else {
         var0 = 3.0;
@@ -37,7 +37,7 @@ def test_bin_num_expr():
 
     expected_code = """
 function score(input) {
-    return ((input[0]) / (-2.0)) * (2.0);
+    return input[0] / -2.0 * 2.0;
 }
 """
 
@@ -63,12 +63,12 @@ def test_dependable_condition():
 function score(input) {
     var var0;
     var var1;
-    if ((1.0) === (1.0)) {
+    if (1.0 === 1.0) {
         var1 = 1.0;
     } else {
         var1 = 2.0;
     }
-    if (((var1) + (2.0)) >= ((1.0) / (2.0))) {
+    if (var1 + 2.0 >= 1.0 / 2.0) {
         var0 = 1.0;
     } else {
         var0 = input[0];
@@ -99,19 +99,19 @@ def test_nested_condition():
 function score(input) {
     var var0;
     var var1;
-    if ((1.0) === (1.0)) {
+    if (1.0 === 1.0) {
         var1 = 1.0;
     } else {
         var1 = 2.0;
     }
-    if ((1.0) === ((var1) + (2.0))) {
+    if (1.0 === var1 + 2.0) {
         var var2;
-        if ((1.0) === (1.0)) {
+        if (1.0 === 1.0) {
             var2 = 1.0;
         } else {
             var2 = 2.0;
         }
-        if ((1.0) === ((var2) + (2.0))) {
+        if (1.0 === var2 + 2.0) {
             var0 = input[2];
         } else {
             var0 = 2.0;
@@ -152,7 +152,7 @@ def test_multi_output():
     expected_code = """
 function score(input) {
     var var0;
-    if ((1.0) !== (1.0)) {
+    if (1.0 !== 1.0) {
         var0 = [1.0, 2.0];
     } else {
         var0 = [3.0, 4.0];
@@ -387,7 +387,7 @@ def test_reused_expr():
 function score(input) {
     var var0;
     var0 = Math.exp(1.0);
-    return (var0) / (var0);
+    return var0 / var0;
 }
 """
 

--- a/tests/interpreters/test_php.py
+++ b/tests/interpreters/test_php.py
@@ -16,7 +16,7 @@ def test_if_expr():
 <?php
 function score(array $input) {
     $var0 = null;
-    if ((1.0) === ($input[0])) {
+    if (1.0 === $input[0]) {
         $var0 = 2.0;
     } else {
         $var0 = 3.0;
@@ -39,7 +39,7 @@ def test_bin_num_expr():
     expected_code = """
 <?php
 function score(array $input) {
-    return (($input[0]) / (-2.0)) * (2.0);
+    return $input[0] / -2.0 * 2.0;
 }
 """
 
@@ -66,12 +66,12 @@ def test_dependable_condition():
 function score(array $input) {
     $var0 = null;
     $var1 = null;
-    if ((1.0) === (1.0)) {
+    if (1.0 === 1.0) {
         $var1 = 1.0;
     } else {
         $var1 = 2.0;
     }
-    if ((($var1) + (2.0)) >= ((1.0) / (2.0))) {
+    if ($var1 + 2.0 >= 1.0 / 2.0) {
         $var0 = 1.0;
     } else {
         $var0 = $input[0];
@@ -103,19 +103,19 @@ def test_nested_condition():
 function score(array $input) {
     $var0 = null;
     $var1 = null;
-    if ((1.0) === (1.0)) {
+    if (1.0 === 1.0) {
         $var1 = 1.0;
     } else {
         $var1 = 2.0;
     }
-    if ((1.0) === (($var1) + (2.0))) {
+    if (1.0 === $var1 + 2.0) {
         $var2 = null;
-        if ((1.0) === (1.0)) {
+        if (1.0 === 1.0) {
             $var2 = 1.0;
         } else {
             $var2 = 2.0;
         }
-        if ((1.0) === (($var2) + (2.0))) {
+        if (1.0 === $var2 + 2.0) {
             $var0 = $input[2];
         } else {
             $var0 = 2.0;
@@ -158,7 +158,7 @@ def test_multi_output():
 <?php
 function score(array $input) {
     $var0 = array();
-    if ((1.0) !== (1.0)) {
+    if (1.0 !== 1.0) {
         $var0 = array(1.0, 2.0);
     } else {
         $var0 = array(3.0, 4.0);
@@ -403,7 +403,7 @@ def test_reused_expr():
 function score(array $input) {
     $var0 = null;
     $var0 = exp(1.0);
-    return ($var0) / ($var0);
+    return $var0 / $var0;
 }
 """
 

--- a/tests/interpreters/test_powershell.py
+++ b/tests/interpreters/test_powershell.py
@@ -15,7 +15,7 @@ def test_if_expr():
     expected_code = """
 function Score([double[]] $InputVector) {
     [double]$var0 = 0.0
-    if ((1.0) -eq ($InputVector[0])) {
+    if (1.0 -eq $InputVector[0]) {
         $var0 = 2.0
     } else {
         $var0 = 3.0
@@ -37,7 +37,7 @@ def test_bin_num_expr():
 
     expected_code = """
 function Score([double[]] $InputVector) {
-    return (($InputVector[0]) / (-2.0)) * (2.0)
+    return $InputVector[0] / -2.0 * 2.0
 }
 """
 
@@ -63,12 +63,12 @@ def test_dependable_condition():
 function Score([double[]] $InputVector) {
     [double]$var0 = 0.0
     [double]$var1 = 0.0
-    if ((1.0) -eq (1.0)) {
+    if (1.0 -eq 1.0) {
         $var1 = 1.0
     } else {
         $var1 = 2.0
     }
-    if ((($var1) + (2.0)) -ge ((1.0) / (2.0))) {
+    if ($var1 + 2.0 -ge 1.0 / 2.0) {
         $var0 = 1.0
     } else {
         $var0 = $InputVector[0]
@@ -99,19 +99,19 @@ def test_nested_condition():
 function Score([double[]] $InputVector) {
     [double]$var0 = 0.0
     [double]$var1 = 0.0
-    if ((1.0) -eq (1.0)) {
+    if (1.0 -eq 1.0) {
         $var1 = 1.0
     } else {
         $var1 = 2.0
     }
-    if ((1.0) -eq (($var1) + (2.0))) {
+    if (1.0 -eq $var1 + 2.0) {
         [double]$var2 = 0.0
-        if ((1.0) -eq (1.0)) {
+        if (1.0 -eq 1.0) {
             $var2 = 1.0
         } else {
             $var2 = 2.0
         }
-        if ((1.0) -eq (($var2) + (2.0))) {
+        if (1.0 -eq $var2 + 2.0) {
             $var0 = $InputVector[2]
         } else {
             $var0 = 2.0
@@ -152,7 +152,7 @@ def test_multi_output():
     expected_code = """
 function Score([double[]] $InputVector) {
     [double[]]$var0 = @(0.0)
-    if ((1.0) -ne (1.0)) {
+    if (1.0 -ne 1.0) {
         $var0 = @($(1.0), $(2.0))
     } else {
         $var0 = @($(3.0), $(4.0))
@@ -441,7 +441,7 @@ def test_reused_expr():
 function Score([double[]] $InputVector) {
     [double]$var0 = 0.0
     $var0 = [math]::Exp(1.0)
-    return ($var0) / ($var0)
+    return $var0 / $var0
 }
 """
 

--- a/tests/interpreters/test_python.py
+++ b/tests/interpreters/test_python.py
@@ -14,7 +14,7 @@ def test_if_expr():
 
     expected_code = """
 def score(input):
-    if (1.0) == (input[0]):
+    if 1.0 == input[0]:
         var0 = 2.0
     else:
         var0 = 3.0
@@ -34,7 +34,7 @@ def test_bin_num_expr():
 
     expected_code = """
 def score(input):
-    return ((input[0]) / (-2.0)) * (2.0)
+    return input[0] / -2.0 * 2.0
 """
 
     interpreter = PythonInterpreter()
@@ -57,11 +57,11 @@ def test_dependable_condition():
 
     expected_code = """
 def score(input):
-    if (1.0) == (1.0):
+    if 1.0 == 1.0:
         var1 = 1.0
     else:
         var1 = 2.0
-    if ((var1) + (2.0)) >= ((1.0) / (2.0)):
+    if var1 + 2.0 >= 1.0 / 2.0:
         var0 = 1.0
     else:
         var0 = input[0]
@@ -88,16 +88,16 @@ def test_nested_condition():
 
     expected_code = """
 def score(input):
-    if (1.0) == (1.0):
+    if 1.0 == 1.0:
         var1 = 1.0
     else:
         var1 = 2.0
-    if (1.0) == ((var1) + (2.0)):
-        if (1.0) == (1.0):
+    if 1.0 == var1 + 2.0:
+        if 1.0 == 1.0:
             var2 = 1.0
         else:
             var2 = 2.0
-        if (1.0) == ((var2) + (2.0)):
+        if 1.0 == var2 + 2.0:
             var0 = input[2]
         else:
             var0 = 2.0
@@ -133,7 +133,7 @@ def test_multi_output():
 
     expected_code = """
 def score(input):
-    if (1.0) != (1.0):
+    if 1.0 != 1.0:
         var0 = [1.0, 2.0]
     else:
         var0 = [3.0, 4.0]
@@ -193,8 +193,8 @@ def test_depth_threshold_with_bin_expr():
 
     expected_code = """
 def score(input):
-    var0 = (1.0) + ((1.0) + (1.0))
-    return (1.0) + ((1.0) + (var0))
+    var0 = 1.0 + (1.0 + 1.0)
+    return 1.0 + (1.0 + var0)
 """
 
     interpreter = CustomPythonInterpreter()
@@ -208,9 +208,9 @@ def test_depth_threshold_with_reused_bin_expr():
 
     expected_code = """
 def score(input):
-    var0 = (1.0) + (1.0)
+    var0 = 1.0 + 1.0
     var1 = var0
-    return ((1.0) + (var1)) + ((1.0) + (var0))
+    return 1.0 + var1 + (1.0 + var0)
 """
 
     interpreter = CustomPythonInterpreter()
@@ -228,16 +228,16 @@ def test_depth_threshold_without_bin_expr():
 
     expected_code = """
 def score(input):
-    if (1.0) == (1.0):
+    if 1.0 == 1.0:
         var0 = 1.0
     else:
-        if (1.0) == (1.0):
+        if 1.0 == 1.0:
             var0 = 1.0
         else:
-            if (1.0) == (1.0):
+            if 1.0 == 1.0:
                 var0 = 1.0
             else:
-                if (1.0) == (1.0):
+                if 1.0 == 1.0:
                     var0 = 1.0
                 else:
                     var0 = 1.0
@@ -262,16 +262,16 @@ def test_deep_mixed_exprs_not_reaching_threshold():
 
     expected_code = """
 def score(input):
-    if ((1.0) + ((1.0) + (1.0))) == (1.0):
+    if 1.0 + (1.0 + 1.0) == 1.0:
         var0 = 1.0
     else:
-        if ((1.0) + ((1.0) + (1.0))) == (1.0):
+        if 1.0 + (1.0 + 1.0) == 1.0:
             var0 = 1.0
         else:
-            if ((1.0) + ((1.0) + (1.0))) == (1.0):
+            if 1.0 + (1.0 + 1.0) == 1.0:
                 var0 = 1.0
             else:
-                if ((1.0) + ((1.0) + (1.0))) == (1.0):
+                if 1.0 + (1.0 + 1.0) == 1.0:
                     var0 = 1.0
                 else:
                     var0 = 1.0
@@ -296,20 +296,20 @@ def test_deep_mixed_exprs_exceeding_threshold():
 
     expected_code = """
 def score(input):
-    var1 = (3.0) + ((3.0) + (1.0))
-    if ((3.0) + ((3.0) + (var1))) == (1.0):
+    var1 = 3.0 + (3.0 + 1.0)
+    if 3.0 + (3.0 + var1) == 1.0:
         var0 = 1.0
     else:
-        var2 = (2.0) + ((2.0) + (1.0))
-        if ((2.0) + ((2.0) + (var2))) == (1.0):
+        var2 = 2.0 + (2.0 + 1.0)
+        if 2.0 + (2.0 + var2) == 1.0:
             var0 = 1.0
         else:
-            var3 = (1.0) + ((1.0) + (1.0))
-            if ((1.0) + ((1.0) + (var3))) == (1.0):
+            var3 = 1.0 + (1.0 + 1.0)
+            if 1.0 + (1.0 + var3) == 1.0:
                 var0 = 1.0
             else:
-                var4 = (0.0) + ((0.0) + (1.0))
-                if ((0.0) + ((0.0) + (var4))) == (1.0):
+                var4 = 0.0 + (0.0 + 1.0)
+                if 0.0 + (0.0 + var4) == 1.0:
                     var0 = 1.0
                 else:
                     var0 = 1.0
@@ -487,7 +487,7 @@ def test_reused_expr():
 import math
 def score(input):
     var0 = math.exp(1.0)
-    return (var0) / (var0)
+    return var0 / var0
 """
 
     interpreter = PythonInterpreter()

--- a/tests/interpreters/test_r.py
+++ b/tests/interpreters/test_r.py
@@ -14,7 +14,7 @@ def test_if_expr():
 
     expected_code = """
 score <- function(input) {
-    if ((1.0) == (input[1])) {
+    if (1.0 == input[1]) {
         var0 <- 2.0
     } else {
         var0 <- 3.0
@@ -36,7 +36,7 @@ def test_bin_num_expr():
 
     expected_code = """
 score <- function(input) {
-    return(((input[1]) / (-2.0)) * (2.0))
+    return(input[1] / -2.0 * 2.0)
 }
 """
 
@@ -60,12 +60,12 @@ def test_dependable_condition():
 
     expected_code = """
 score <- function(input) {
-    if ((1.0) == (1.0)) {
+    if (1.0 == 1.0) {
         var1 <- 1.0
     } else {
         var1 <- 2.0
     }
-    if (((var1) + (2.0)) >= ((1.0) / (2.0))) {
+    if (var1 + 2.0 >= 1.0 / 2.0) {
         var0 <- 1.0
     } else {
         var0 <- input[1]
@@ -94,18 +94,18 @@ def test_nested_condition():
 
     expected_code = """
 score <- function(input) {
-    if ((1.0) == (1.0)) {
+    if (1.0 == 1.0) {
         var1 <- 1.0
     } else {
         var1 <- 2.0
     }
-    if ((1.0) == ((var1) + (2.0))) {
-        if ((1.0) == (1.0)) {
+    if (1.0 == var1 + 2.0) {
+        if (1.0 == 1.0) {
             var2 <- 1.0
         } else {
             var2 <- 2.0
         }
-        if ((1.0) == ((var2) + (2.0))) {
+        if (1.0 == var2 + 2.0) {
             var0 <- input[3]
         } else {
             var0 <- 2.0
@@ -145,7 +145,7 @@ def test_multi_output():
 
     expected_code = """
 score <- function(input) {
-    if ((1.0) != (1.0)) {
+    if (1.0 != 1.0) {
         var0 <- c(1.0, 2.0)
     } else {
         var0 <- c(3.0, 4.0)
@@ -166,7 +166,7 @@ def test_bin_vector_expr():
 
     expected_code = """
 score <- function(input) {
-    return((c(1.0, 2.0)) + (c(3.0, 4.0)))
+    return(c(1.0, 2.0) + c(3.0, 4.0))
 }
 """
 
@@ -182,7 +182,7 @@ def test_bin_vector_num_expr():
 
     expected_code = """
 score <- function(input) {
-    return((c(1.0, 2.0)) * (1.0))
+    return(c(1.0, 2.0) * 1.0)
 }
 """
 
@@ -201,8 +201,8 @@ def test_depth_threshold_with_bin_expr():
 
     expected_code = """
 score <- function(input) {
-    var0 <- (1.0) + ((1.0) + (1.0))
-    return((1.0) + ((1.0) + (var0)))
+    var0 <- 1.0 + (1.0 + 1.0)
+    return(1.0 + (1.0 + var0))
 }
 """
 
@@ -217,9 +217,9 @@ def test_depth_threshold_with_reused_bin_expr():
 
     expected_code = """
 score <- function(input) {
-    var0 <- (1.0) + (1.0)
+    var0 <- 1.0 + 1.0
     var1 <- var0
-    return(((1.0) + (var1)) + ((1.0) + (var0)))
+    return(1.0 + var1 + (1.0 + var0))
 }
 """
 
@@ -238,16 +238,16 @@ def test_depth_threshold_without_bin_expr():
 
     expected_code = """
 score <- function(input) {
-    if ((1.0) == (1.0)) {
+    if (1.0 == 1.0) {
         var0 <- 1.0
     } else {
-        if ((1.0) == (1.0)) {
+        if (1.0 == 1.0) {
             var0 <- 1.0
         } else {
-            if ((1.0) == (1.0)) {
+            if (1.0 == 1.0) {
                 var0 <- 1.0
             } else {
-                if ((1.0) == (1.0)) {
+                if (1.0 == 1.0) {
                     var0 <- 1.0
                 } else {
                     var0 <- 1.0
@@ -278,16 +278,16 @@ def test_deep_mixed_exprs_not_reaching_threshold():
 
     expected_code = """
 score <- function(input) {
-    if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+    if (1.0 + (1.0 + 1.0) == 1.0) {
         var0 <- 1.0
     } else {
-        if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+        if (1.0 + (1.0 + 1.0) == 1.0) {
             var0 <- 1.0
         } else {
-            if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+            if (1.0 + (1.0 + 1.0) == 1.0) {
                 var0 <- 1.0
             } else {
-                if (((1.0) + ((1.0) + (1.0))) == (1.0)) {
+                if (1.0 + (1.0 + 1.0) == 1.0) {
                     var0 <- 1.0
                 } else {
                     var0 <- 1.0
@@ -319,19 +319,19 @@ def test_deep_mixed_exprs_exceeding_threshold():
     expected_code = """
 score <- function(input) {
     var1 <- subroutine0(input)
-    if (((3.0) + (var1)) == (1.0)) {
+    if (3.0 + var1 == 1.0) {
         var0 <- 1.0
     } else {
         var2 <- subroutine1(input)
-        if (((2.0) + (var2)) == (1.0)) {
+        if (2.0 + var2 == 1.0) {
             var0 <- 1.0
         } else {
             var3 <- subroutine2(input)
-            if (((1.0) + (var3)) == (1.0)) {
+            if (1.0 + var3 == 1.0) {
                 var0 <- 1.0
             } else {
                 var4 <- subroutine3(input)
-                if (((0.0) + (var4)) == (1.0)) {
+                if (0.0 + var4 == 1.0) {
                     var0 <- 1.0
                 } else {
                     var0 <- 1.0
@@ -342,24 +342,24 @@ score <- function(input) {
     return(var0)
 }
 subroutine0 <- function(input) {
-    var0 <- (3.0) + (1.0)
-    var1 <- (3.0) + (var0)
-    return((3.0) + (var1))
+    var0 <- 3.0 + 1.0
+    var1 <- 3.0 + var0
+    return(3.0 + var1)
 }
 subroutine1 <- function(input) {
-    var0 <- (2.0) + (1.0)
-    var1 <- (2.0) + (var0)
-    return((2.0) + (var1))
+    var0 <- 2.0 + 1.0
+    var1 <- 2.0 + var0
+    return(2.0 + var1)
 }
 subroutine2 <- function(input) {
-    var0 <- (1.0) + (1.0)
-    var1 <- (1.0) + (var0)
-    return((1.0) + (var1))
+    var0 <- 1.0 + 1.0
+    var1 <- 1.0 + var0
+    return(1.0 + var1)
 }
 subroutine3 <- function(input) {
-    var0 <- (0.0) + (1.0)
-    var1 <- (0.0) + (var0)
-    return((0.0) + (var1))
+    var0 <- 0.0 + 1.0
+    var1 <- 0.0 + var0
+    return(0.0 + var1)
 }
 """
 
@@ -401,7 +401,7 @@ def test_pow_expr():
 
     expected_code = """
 score <- function(input) {
-    return((2.0) ^ (3.0))
+    return(2.0 ^ 3.0)
 }
 """
 
@@ -520,7 +520,7 @@ def test_reused_expr():
     expected_code = """
 score <- function(input) {
     var0 <- exp(1.0)
-    return((var0) / (var0))
+    return(var0 / var0)
 }
 """
 

--- a/tests/interpreters/test_ruby.py
+++ b/tests/interpreters/test_ruby.py
@@ -14,7 +14,7 @@ def test_if_expr():
 
     expected_code = """
 def score(input)
-    if (1.0) == (input[0])
+    if 1.0 == input[0]
         var0 = 2.0
     else
         var0 = 3.0
@@ -36,7 +36,7 @@ def test_bin_num_expr():
 
     expected_code = """
 def score(input)
-    ((input[0]).fdiv(-2.0)) * (2.0)
+    (input[0]).fdiv(-2.0) * 2.0
 end
 """
 
@@ -60,12 +60,12 @@ def test_dependable_condition():
 
     expected_code = """
 def score(input)
-    if (1.0) == (1.0)
+    if 1.0 == 1.0
         var1 = 1.0
     else
         var1 = 2.0
     end
-    if ((var1) + (2.0)) >= ((1.0).fdiv(2.0))
+    if var1 + 2.0 >= (1.0).fdiv(2.0)
         var0 = 1.0
     else
         var0 = input[0]
@@ -94,18 +94,18 @@ def test_nested_condition():
 
     expected_code = """
 def score(input)
-    if (1.0) == (1.0)
+    if 1.0 == 1.0
         var1 = 1.0
     else
         var1 = 2.0
     end
-    if (1.0) == ((var1) + (2.0))
-        if (1.0) == (1.0)
+    if 1.0 == var1 + 2.0
+        if 1.0 == 1.0
             var2 = 1.0
         else
             var2 = 2.0
         end
-        if (1.0) == ((var2) + (2.0))
+        if 1.0 == var2 + 2.0
             var0 = input[2]
         else
             var0 = 2.0
@@ -145,7 +145,7 @@ def test_multi_output():
 
     expected_code = """
 def score(input)
-    if (1.0) != (1.0)
+    if 1.0 != 1.0
         var0 = [1.0, 2.0]
     else
         var0 = [3.0, 4.0]
@@ -233,7 +233,7 @@ def test_pow_expr():
 
     expected_code = """
 def score(input)
-    (2.0) ** (3.0)
+    2.0 ** 3.0
 end
 """
 

--- a/tests/interpreters/test_rust.py
+++ b/tests/interpreters/test_rust.py
@@ -15,7 +15,7 @@ def test_if_expr():
     expected_code = """
 fn score(input: Vec<f64>) -> f64 {
     let var0: f64;
-    if (1.0_f64) == (input[0]) {
+    if 1.0_f64 == input[0] {
         var0 = 2.0_f64;
     } else {
         var0 = 3.0_f64;
@@ -37,7 +37,7 @@ def test_bin_num_expr():
 
     expected_code = """
 fn score(input: Vec<f64>) -> f64 {
-    ((input[0]) / (-2.0_f64)) * (2.0_f64)
+    input[0] / -2.0_f64 * 2.0_f64
 }
 """
 
@@ -63,12 +63,12 @@ def test_dependable_condition():
 fn score(input: Vec<f64>) -> f64 {
     let var0: f64;
     let var1: f64;
-    if (1.0_f64) == (1.0_f64) {
+    if 1.0_f64 == 1.0_f64 {
         var1 = 1.0_f64;
     } else {
         var1 = 2.0_f64;
     }
-    if ((var1) + (2.0_f64)) >= ((1.0_f64) / (2.0_f64)) {
+    if var1 + 2.0_f64 >= 1.0_f64 / 2.0_f64 {
         var0 = 1.0_f64;
     } else {
         var0 = input[0];
@@ -99,19 +99,19 @@ def test_nested_condition():
 fn score(input: Vec<f64>) -> f64 {
     let var0: f64;
     let var1: f64;
-    if (1.0_f64) == (1.0_f64) {
+    if 1.0_f64 == 1.0_f64 {
         var1 = 1.0_f64;
     } else {
         var1 = 2.0_f64;
     }
-    if (1.0_f64) == ((var1) + (2.0_f64)) {
+    if 1.0_f64 == var1 + 2.0_f64 {
         let var2: f64;
-        if (1.0_f64) == (1.0_f64) {
+        if 1.0_f64 == 1.0_f64 {
             var2 = 1.0_f64;
         } else {
             var2 = 2.0_f64;
         }
-        if (1.0_f64) == ((var2) + (2.0_f64)) {
+        if 1.0_f64 == var2 + 2.0_f64 {
             var0 = input[2];
         } else {
             var0 = 2.0_f64;
@@ -152,7 +152,7 @@ def test_multi_output():
     expected_code = """
 fn score(input: Vec<f64>) -> Vec<f64> {
     let var0: Vec<f64>;
-    if (1.0_f64) != (1.0_f64) {
+    if 1.0_f64 != 1.0_f64 {
         var0 = vec![1.0_f64, 2.0_f64];
     } else {
         var0 = vec![3.0_f64, 4.0_f64];
@@ -365,7 +365,7 @@ def test_reused_expr():
 fn score(input: Vec<f64>) -> f64 {
     let var0: f64;
     var0 = f64::exp(1.0_f64);
-    (var0) / (var0)
+    var0 / var0
 }
 """
 

--- a/tests/interpreters/test_visual_basic.py
+++ b/tests/interpreters/test_visual_basic.py
@@ -16,7 +16,7 @@ def test_if_expr():
 Module Model
 Function Score(ByRef inputVector() As Double) As Double
     Dim var0 As Double
-    If (1.0) = (inputVector(0)) Then
+    If 1.0 = inputVector(0) Then
         var0 = 2.0
     Else
         var0 = 3.0
@@ -40,7 +40,7 @@ def test_bin_num_expr():
     expected_code = """
 Module Model
 Function Score(ByRef inputVector() As Double) As Double
-    Score = ((inputVector(0)) / (-2.0)) * (2.0)
+    Score = inputVector(0) / -2.0 * 2.0
 End Function
 End Module
 """
@@ -68,12 +68,12 @@ Module Model
 Function Score(ByRef inputVector() As Double) As Double
     Dim var0 As Double
     Dim var1 As Double
-    If (1.0) = (1.0) Then
+    If 1.0 = 1.0 Then
         var1 = 1.0
     Else
         var1 = 2.0
     End If
-    If ((var1) + (2.0)) >= ((1.0) / (2.0)) Then
+    If var1 + 2.0 >= 1.0 / 2.0 Then
         var0 = 1.0
     Else
         var0 = inputVector(0)
@@ -106,19 +106,19 @@ Module Model
 Function Score(ByRef inputVector() As Double) As Double
     Dim var0 As Double
     Dim var1 As Double
-    If (1.0) = (1.0) Then
+    If 1.0 = 1.0 Then
         var1 = 1.0
     Else
         var1 = 2.0
     End If
-    If (1.0) = ((var1) + (2.0)) Then
+    If 1.0 = var1 + 2.0 Then
         Dim var2 As Double
-        If (1.0) = (1.0) Then
+        If 1.0 = 1.0 Then
             var2 = 1.0
         Else
             var2 = 2.0
         End If
-        If (1.0) = ((var2) + (2.0)) Then
+        If 1.0 = var2 + 2.0 Then
             var0 = inputVector(2)
         Else
             var0 = 2.0
@@ -181,7 +181,7 @@ def test_multi_output():
 Module Model
 Function Score(ByRef inputVector() As Double) As Double()
     Dim var0() As Double
-    If (1.0) <> (1.0) Then
+    If 1.0 <> 1.0 Then
         Dim var1(1) As Double
         var1(0) = 1.0
         var1(1) = 2.0
@@ -334,7 +334,7 @@ def test_pow_expr():
     expected_code = """
 Module Model
 Function Score(ByRef inputVector() As Double) As Double
-    Score = (2.0) ^ (3.0)
+    Score = 2.0 ^ 3.0
 End Function
 End Module
 """
@@ -349,7 +349,7 @@ def test_sqrt_expr():
     expected_code = """
 Module Model
 Function Score(ByRef inputVector() As Double) As Double
-    Score = (2.0) ^ (0.5)
+    Score = 2.0 ^ 0.5
 End Function
 End Module
 """
@@ -644,7 +644,7 @@ Module Model
 Function Score(ByRef inputVector() As Double) As Double
     Dim var0 As Double
     var0 = Math.Exp(1.0)
-    Score = (var0) / (var0)
+    Score = var0 / var0
 End Function
 End Module
 """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,7 +130,7 @@ def test_indent(pickled_model):
 namespace ML {
 public static class Model {
 public static double Score(double[] input) {
-return (
+return
 """.strip())
 
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -6,7 +6,7 @@ def test_export_to_java(trained_model):
     assert generated_code.startswith("""
 public class Model {
     public static double score(double[] input) {
-        return (
+        return
 """.strip())
 
 
@@ -14,7 +14,7 @@ def test_export_to_python(trained_model):
     generated_code = exporters.export_to_python(trained_model).strip()
     assert generated_code.startswith("""
 def score(input):
-    return (
+    return
 """.strip())
 
 
@@ -22,7 +22,7 @@ def test_export_to_c(trained_model):
     generated_code = exporters.export_to_c(trained_model).strip()
     assert generated_code.startswith("""
 double score(double * input) {
-    return (
+    return
 """.strip())
 
 
@@ -30,7 +30,7 @@ def test_export_to_go(trained_model):
     generated_code = exporters.export_to_go(trained_model).strip()
     assert generated_code.startswith("""
 func score(input []float64) float64 {
-    return (
+    return
 """.strip())
 
 
@@ -38,7 +38,7 @@ def test_export_to_javascript(trained_model):
     generated_code = exporters.export_to_javascript(trained_model).strip()
     assert generated_code.startswith("""
 function score(input) {
-    return (
+    return
 """.strip())
 
 
@@ -47,7 +47,7 @@ def test_export_to_visual_basic(trained_model):
     assert generated_code.startswith("""
 Module Model
 Function Score(ByRef inputVector() As Double) As Double
-    Score = (
+    Score =
 """.strip())
 
 
@@ -57,7 +57,7 @@ def test_export_to_c_sharp(trained_model):
 namespace ML {
     public static class Model {
         public static double Score(double[] input) {
-            return (
+            return
 """.strip())
 
 
@@ -65,7 +65,7 @@ def test_export_to_powershell(trained_model):
     generated_code = exporters.export_to_powershell(trained_model).strip()
     assert generated_code.startswith("""
 function Score([double[]] $InputVector) {
-    return (
+    return
 """.strip())
 
 
@@ -82,7 +82,7 @@ def test_export_to_php(trained_model):
     assert generated_code.startswith("""
 <?php
 function score(array $input) {
-    return (
+    return
 """.strip())
 
 
@@ -90,7 +90,7 @@ def test_export_to_dart(trained_model):
     generated_code = exporters.export_to_dart(trained_model).strip()
     assert generated_code.startswith("""
 double score(List<double> input) {
-    return (
+    return
 """.strip())
 
 
@@ -100,7 +100,6 @@ def test_export_to_haskell(trained_model):
 module Model where
 score :: [Double] -> Double
 score input =
-    (
 """.strip())
 
 
@@ -108,7 +107,6 @@ def test_export_to_ruby(trained_model):
     generated_code = exporters.export_to_ruby(trained_model).strip()
     assert generated_code.startswith("""
 def score(input)
-    (
 """.strip())
 
 
@@ -116,7 +114,6 @@ def test_export_to_f_sharp(trained_model):
     generated_code = exporters.export_to_f_sharp(trained_model).strip()
     assert generated_code.startswith("""
 let score (input : double list) =
-    (
 """.strip())
 
 
@@ -124,5 +121,4 @@ def test_export_to_rust(trained_model):
     generated_code = exporters.export_to_rust(trained_model).strip()
     assert generated_code.startswith("""
 fn score(input: Vec<f64>) -> f64 {
-    (
 """.strip())

--- a/tests/test_fallback_expressions.py
+++ b/tests/test_fallback_expressions.py
@@ -33,8 +33,8 @@ double score(double * input) {
     double var0;
     double var1;
     var1 = -2.0;
-    if ((var1) < (0.0)) {
-        var0 = (0.0) - (var1);
+    if (var1 < 0.0) {
+        var0 = 0.0 - var1;
     } else {
         var0 = var1;
     }
@@ -55,13 +55,13 @@ def test_tanh_fallback_expr():
 import math
 def score(input):
     var1 = 2.0
-    if (var1) > (44.0):
+    if var1 > 44.0:
         var0 = 1.0
     else:
-        if (var1) < (-44.0):
+        if var1 < -44.0:
             var0 = -1.0
         else:
-            var0 = (1.0) - ((2.0) / ((math.exp((2.0) * (var1))) + (1.0)))
+            var0 = 1.0 - 2.0 / (math.exp(2.0 * var1) + 1.0)
     return var0
 """
 
@@ -108,12 +108,12 @@ def test_log1p_fallback_expr():
 import math
 def score(input):
     var1 = 2.0
-    var2 = (1.0) + (var1)
-    var3 = (var2) - (1.0)
-    if (var3) == (0.0):
+    var2 = 1.0 + var1
+    var3 = var2 - 1.0
+    if var3 == 0.0:
         var0 = var1
     else:
-        var0 = ((var1) * (math.log(var2))) / (var3)
+        var0 = var1 * math.log(var2) / var3
     return var0
 """
 
@@ -126,43 +126,36 @@ def test_atan_fallback_expr():
     interpreter = PythonInterpreter()
     interpreter.atan_function_name = NotImplemented
 
-    expected_code = (
-        """
-def score(input):
+    expected_code = """
+ def score(input):
     var1 = 2.0
     var2 = abs(var1)
-    if (var2) > (2.414213562373095):
-        var0 = (1.0) / (var2)
+    if var2 > 2.414213562373095:
+        var0 = 1.0 / var2
     else:
-        if (var2) > (0.66):
-            var0 = ((var2) - (1.0)) / ((var2) + (1.0))
+        if var2 > 0.66:
+            var0 = (var2 - 1.0) / (var2 + 1.0)
         else:
             var0 = var2
     var3 = var0
-    var4 = (var3) * (var3)
-    if (var2) > (2.414213562373095):
+    var4 = var3 * var3
+    if var2 > 2.414213562373095:
         var5 = -1.0
     else:
         var5 = 1.0
-    if (var2) <= (0.66):
+    if var2 <= 0.66:
         var6 = 0.0
     else:
-        if (var2) > (2.414213562373095):
+        if var2 > 2.414213562373095:
             var6 = 1.5707963267948968
         else:
             var6 = 0.7853981633974484
-    if (var1) < (0.0):
+    if var1 < 0.0:
         var7 = -1.0
     else:
         var7 = 1.0
-    return (((((var3) * ((var4) * ((((var4) * (((var4) * (((var4) * """
-        """(((var4) * (-0.8750608600031904)) - (16.157537187333652))) - """
-        """(75.00855792314705))) - (122.88666844901361))) - """
-        """(64.85021904942025)) / ((194.5506571482614) + ((var4) * """
-        """((485.3903996359137) + ((var4) * ((432.88106049129027) + """
-        """((var4) * ((165.02700983169885) + ((var4) * """
-        """((24.858464901423062) + (var4))))))))))))) + (var3)) * """
-        """(var5)) + (var6)) * (var7)""")
+    return ((var3 * (var4 * ((var4 * (var4 * (var4 * (var4 * -0.8750608600031904 - 16.157537187333652) - 75.00855792314705) - 122.88666844901361) - 64.85021904942025) / (194.5506571482614 + var4 * (485.3903996359137 + var4 * (432.88106049129027 + var4 * (165.02700983169885 + var4 * (24.858464901423062 + var4))))))) + var3) * var5 + var6) * var7
+"""  # noqa: E501
 
     assert_code_equal(interpreter.interpret(expr), expected_code)
 
@@ -184,8 +177,8 @@ import math
 def score(input):
     var0 = math.exp(2.0)
     var1 = math.exp(3.0)
-    var2 = (var0) + (var1)
-    return [(var0) / (var2), (var1) / (var2)]
+    var2 = (var0 + var1)
+    return [var0 / var2, var1 / var2]
 """
 
     assert_code_equal(interpreter.interpret(expr), expected_code)
@@ -206,7 +199,7 @@ def test_sigmoid_fallback_expr():
     expected_code = """
 import math
 def score(input):
-    return (1.0) / ((1.0) + (math.exp((0.0) - (2.0))))
+    return 1.0 / (1.0 + math.exp(0.0 - 2.0))
 """
 
     assert_code_equal(interpreter.interpret(expr), expected_code)


### PR DESCRIPTION
Admittedly the original idea of wrapping each operand of an infix expression into parentheses was a half-assed solution. 
I've noticed recurrent complains from users who mentioned bloated file size, crashed editors, etc. So I figured I try and introduce the proper operator precedence to the code generation logic and only add parentheses where they are necessary.