### PR TITLE
Generate artifact with code examples

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -9,6 +9,7 @@ if [[ $TEST == "API" ]]; then
   wget -q https://uploader.codecov.io/latest/linux/codecov -O codecov
   chmod +x codecov
   ./codecov -f coverage.xml -Z
+  python tools/generate_code_examples.py ./generated_code_examples
 fi
 
 if [[ $TEST == "E2E" ]]; then

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -6,9 +6,9 @@ if [[ $TEST == "API" ]]; then
   # Run code linters
   flake8 .
   isort . --check-only
-  # Run tests
+  # Run tests with code coverage
   pytest -v tests/ --cov=m2cgen/ --cov-report=xml:coverage.xml --ignore=tests/e2e/
-  # Run code coverage
+  # Upload code coverage
   wget -q https://uploader.codecov.io/latest/linux/codecov -O codecov
   chmod +x codecov
   ./codecov -f coverage.xml -Z

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -3,12 +3,17 @@
 set -e
 
 if [[ $TEST == "API" ]]; then
+  # Run code linters
   flake8 .
   isort . --check-only
+  # Run tests
   pytest -v tests/ --cov=m2cgen/ --cov-report=xml:coverage.xml --ignore=tests/e2e/
+  # Run code coverage
   wget -q https://uploader.codecov.io/latest/linux/codecov -O codecov
   chmod +x codecov
   ./codecov -f coverage.xml -Z
+  # Generate code examples
+  python setup.py develop
   python tools/generate_code_examples.py ./generated_code_examples
 fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,16 +17,16 @@ jobs:
       matrix:
         python:
           - "3.7"
-#          - "3.8"
-#          - "3.9"
+          - "3.8"
+          - "3.9"
           - "3.10"
         lang:
           - "API"
-#          - "c_lang or python or java or go_lang or javascript or php or haskell or ruby or rust"
-#          - "c_sharp or visual_basic or f_sharp"
-#          - "r_lang"
-#          - "elixir"
-#          - "dart or powershell"
+          - "c_lang or python or java or go_lang or javascript or php or haskell or ruby or rust"
+          - "c_sharp or visual_basic or f_sharp"
+          - "r_lang"
+          - "elixir"
+          - "dart or powershell"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -63,6 +63,7 @@ jobs:
         with:
           name: code_examples
           path: ${{ github.workspace }}/generated_code_examples/
+          if-no-files-found: error
   all-successful:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: code_examples
-          path: $GITHUB_WORKSPACE/generated_code_examples/
+          path: ${{ github.workspace }}/generated_code_examples/
   all-successful:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,16 +17,16 @@ jobs:
       matrix:
         python:
           - "3.7"
-          - "3.8"
-          - "3.9"
+#          - "3.8"
+#          - "3.9"
           - "3.10"
         lang:
           - "API"
-          - "c_lang or python or java or go_lang or javascript or php or haskell or ruby or rust"
-          - "c_sharp or visual_basic or f_sharp"
-          - "r_lang"
-          - "elixir"
-          - "dart or powershell"
+#          - "c_lang or python or java or go_lang or javascript or php or haskell or ruby or rust"
+#          - "c_sharp or visual_basic or f_sharp"
+#          - "r_lang"
+#          - "elixir"
+#          - "dart or powershell"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -57,6 +57,12 @@ jobs:
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             m2cgen-docker \
             bash /m2cgen/.ci/test.sh
+      - name: Generate artifact with code examples
+        if: matrix.python == '3.10' && matrix.lang == 'API'
+        uses: actions/upload-artifact@v3
+        with:
+          name: code_examples
+          path: $GITHUB_WORKSPACE/generated_code_examples/
   all-successful:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use GitHub Actions to generate code examples for each commit and pack them into a downloadable artifact.
Artifact can be downloaded then from corresponding CI job page (can be found under the **Artifacts** heading after all jobs are finished).
![image](https://user-images.githubusercontent.com/25141164/160938458-ed4ac224-6e4e-424a-abb7-9a92232b949f.png)
