### PR TITLE
fix joblib model loading

### DIFF
--- a/m2cgen/cli.py
+++ b/m2cgen/cli.py
@@ -7,7 +7,6 @@ Example usage:
 Model can also be piped:
     # cat <path_to_file> | m2cgen --language java
 """
-import pickle
 import sys
 from argparse import ArgumentParser, FileType
 from inspect import signature
@@ -99,6 +98,13 @@ parser.add_argument(
     "--version", "-v",
     action="version",
     version=f"%(prog)s {m2cgen.__version__}")
+parser.add_argument(
+    "--pickle-lib", "-pl",
+    type=str,
+    dest="lib",
+    help="Sets the lib used to save the model",
+    choices=["pickle","joblib"],
+    default="pickle")
 
 
 def parse_args(args):
@@ -109,7 +115,8 @@ def generate_code(args):
     sys.setrecursionlimit(args.recursion_limit)
 
     with args.infile as f:
-        model = pickle.load(f)
+        pickle_lib = __import__(args.lib)
+        model = pickle_lib.load(f)
 
     exporter, supported_args = LANGUAGE_TO_EXPORTER[args.language]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,8 @@ def _get_mock_args(
     package_name=None,
     class_name=None,
     infile=None,
-    language=None
+    language=None,
+    lib="pickle"
 ):
     return mock.MagicMock(
         indent=indent,
@@ -28,7 +29,8 @@ def _get_mock_args(
         class_name=class_name,
         infile=infile,
         language=language,
-        recursion_limit=cli.MAX_RECURSION_DEPTH)
+        recursion_limit=cli.MAX_RECURSION_DEPTH,
+        lib=lib)
 
 
 def test_file_as_input(tmp_path):
@@ -121,6 +123,11 @@ def test_namespace(pickled_model):
 
     assert "namespace Tests.ML {" in generated_code
 
+def test_joblib_loading(pickled_model):
+    mock_args = _get_mock_args(infile=pickled_model, language="go", lib="joblib")
+    generated_code = cli.generate_code(mock_args).strip()
+
+    assert generated_code.startswith("func score(input []float64) float64 {\n")
 
 def test_indent(pickled_model):
     mock_args = _get_mock_args(infile=pickled_model, indent=0, language="c_sharp")


### PR DESCRIPTION
Hi! I faced the problem that some models that were dumped using joblib cannot be loaded using pickle in m2cgen i.e. DecisionTreeClassifier from scikit-learn. This leads to undefined behavior further down in the code.

Works file:
```
from pickle import dump
f = open("model.pkl","wb")
clf = DecisionTreeClassifier()
clf = clf.fit(X_train,y_train)
dump(clf, f) 
```

Won't work:
```
from joblib import dump
clf = DecisionTreeClassifier()
clf = clf.fit(X_train,y_train)
dump(clf, "model.pkl") 
```

Traceback looks like:
```
Traceback (most recent call last):
  File "~/miniconda3/bin/m2cgen", line 8, in <module>
    sys.exit(main())
  File "~/miniconda3/lib/python3.9/site-packages/m2cgen/cli.py", line 137, in main
    print(generate_code(args))
  File "~/miniconda3/lib/python3.9/site-packages/m2cgen/cli.py", line 132, in generate_code
    return exporter(model, **kwargs)
  File "~/miniconda3/lib/python3.9/site-packages/m2cgen/exporters.py", line 33, in export_to_java
    return _export(model, interpreter)
  File "~/miniconda3/lib/python3.9/site-packages/m2cgen/exporters.py", line 458, in _export
    assembler_cls = get_assembler_cls(model)
  File "~/miniconda3/lib/python3.9/site-packages/m2cgen/assemblers/__init__.py", line 147, in get_assembler_cls
    raise NotImplementedError(f"Model '{model_name}' is not supported")
NotImplementedError: Model 'numpy_ndarray' is not supported
```

By the way, I'm not the only one with this problem.
https://github.com/BayesWitnesses/m2cgen/issues/287