### PR TITLE
Add `joblib` to tests' dependencies

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,3 +18,4 @@ numpy==1.23.3; python_version > "3.7"
 numpy==1.21.5; python_version <= "3.7"
 scipy==1.9.1; python_version > "3.7"
 scipy==1.7.3; python_version <= "3.7"
+joblib==1.2.0


### PR DESCRIPTION
Related #542.

With recently added test
https://github.com/BayesWitnesses/m2cgen/blob/b0f76ef3ad287ced9fc777ecd2a97300180aa9d2/tests/test_cli.py#L127-L131
we need `joblib` library installed during running API tests.

I believe it's better to install this library explicitly rather than relying on indirect installation of `joblib` along with `scikit-learn`.