### PR TITLE
Add Support for XGBRanker

### DIFF
--- a/m2cgen/assemblers/__init__.py
+++ b/m2cgen/assemblers/__init__.py
@@ -46,6 +46,7 @@ SUPPORTED_MODELS = {
     "xgboost_XGBRFClassifier": XGBoostModelAssemblerSelector,
     "xgboost_XGBRegressor": XGBoostModelAssemblerSelector,
     "xgboost_XGBRFRegressor": XGBoostModelAssemblerSelector,
+    "xgboost_XGBRanker": XGBoostModelAssemblerSelector,
 
     # Sklearn SVM
     "sklearn_LinearSVC": SklearnLinearModelAssembler,


### PR DESCRIPTION
In this request, I am adding support for exporting XGBRanker models. These models are same as XGBRegressor models internally in terms of how they work. These are single output regressors this by just adding a support for it, its expected to work without any changes.I validated the change works.