### PR TITLE
c: Fix compile errors when vector init is used in a macro

### DIFF
--- a/m2cgen/interpreters/c/code_generator.py
+++ b/m2cgen/interpreters/c/code_generator.py
@@ -54,7 +54,7 @@ class CCodeGenerator(CLikeCodeGenerator):
         self.prepend_code_line(f"#include {dep}")
 
     def vector_init(self, values):
-        return f"(double[]){{{', '.join(values)}}}"
+        return f"((double[]){{{', '.join(values)}}})"
 
     def _get_var_declare_type(self, is_vector):
         return self.vector_type if is_vector else self.scalar_type


### PR DESCRIPTION
On some platforms, memcpy is a macro. Example: Raspberry Pi RP2040. In this case, the commas inside the array initializer gets mis-interpreted as macro argument separators. Adding an outer parenthesis fixes this issue.

Fixes compile errors with trees, on form

    .../model_m2cgen.h:5343:115: error: macro "memcpy" passed 8 arguments, but takes just 3
     5343 |                                         memcpy(var19, (double[]){0.0, 0.0, 0.0, 0.0, 1.0, 0.0}, 6 * sizeof(double));
          |                                                                                                                   ^
    .../zephyr-sdk-0.16.5/arm-zephyr-eabi/picolibc/include/ssp/string.h:97: note: macro "memcpy" defined here
       97 | #define memcpy(dst, src, len) __ssp_bos_check3(memcpy, dst, src, len)