### PR TITLE
Adjusting base_score for BaseBoostingAssembler and XGBoostTreeModelAssembler

### DIFF
--- a/m2cgen/assemblers/boosting.py
+++ b/m2cgen/assemblers/boosting.py
@@ -17,7 +17,10 @@ class BaseBoostingAssembler(ModelAssembler):
     def __init__(self, model, estimator_params, base_score=0.0):
         super().__init__(model)
         self._all_estimator_params = estimator_params
-        self._base_score = base_score
+        if base_score is None:
+            self._base_score = 0.0
+        else:
+            self._base_score = base_score
 
         self._output_size = 1
         self._is_classification = False
@@ -141,10 +144,15 @@ class XGBoostTreeModelAssembler(BaseTreeBoostingAssembler):
         # Limit the number of trees that should be used for
         # assembling (if applicable).
         best_ntree_limit = getattr(model, "best_ntree_limit", None)
-
+        if model.get_params().get("base_score") is not None:
+            base_score = model.get_params()["base_score"]
+        elif model.intercept_ is not None:
+            base_score = model.intercept_[0]
+        else:
+            base_score = 0.0
         super().__init__(model,
                          trees,
-                         base_score=model.get_params()["base_score"],
+                         base_score=base_score,
                          tree_limit=best_ntree_limit)
 
     def _assemble_tree(self, tree):


### PR DESCRIPTION
First of all thank you for the library, I really appreciate using it. I am not to familiar with python libraries so excuse me if I am missing something obvious. 
Problem: 
When generating XGBoost models I came across the error:
```CLI
File “[…].venv/lib/python3.13/site-packages/m2cgen/assemblers/boosting.py", line 80, in _assemble_bin_class_output
    base_score = -math.log(1.0 / self._base_score - 1.0)
                           ~~~~^~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for /: 'float' and 'NoneType'
```
XGBoost 2.0 New says:
> In the previous version, `base_score` was a constant that could be set as a training parameter. In the new version, XGBoost can automatically estimate this parameter based on input labels for optimal accuracy. (#8539, #8498, #8272, #8793, #8607)

[github](https://github.com/dmlc/xgboost/blob/d497d907d4c6723a846effc39689d38b8cd3fa08/NEWS.md?plain=1#L52) 

Proposed solution:

To be compatible I check for None in `BaseBoostingAssembler` and check the two different ways (`model.get_params().get("base_score")` and `model.intercept_ is not None`) in `XGBoostTreeModelAssembler` passing it to the super. 

Related:
#587 #581 

Thanks for your feedback! 
